### PR TITLE
feat: Pagination UI für Kernlisten (Issue #44)

### DIFF
--- a/frontend/src/components/PaginationControls.test.ts
+++ b/frontend/src/components/PaginationControls.test.ts
@@ -1,0 +1,75 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import PaginationControls from '@/components/PaginationControls.vue'
+
+describe('PaginationControls', () => {
+  it('renders nothing when lastPage is 1', () => {
+    const wrapper = mount(PaginationControls, {
+      props: { currentPage: 1, lastPage: 1 },
+    })
+
+    expect(wrapper.find('div').exists()).toBe(false)
+  })
+
+  it('renders pagination when lastPage > 1', () => {
+    const wrapper = mount(PaginationControls, {
+      props: { currentPage: 2, lastPage: 5 },
+    })
+
+    expect(wrapper.text()).toContain('Seite 2 von 5')
+    expect(wrapper.text()).toContain('Vorherige')
+    expect(wrapper.text()).toContain('Nächste')
+  })
+
+  it('shows total count when provided', () => {
+    const wrapper = mount(PaginationControls, {
+      props: { currentPage: 1, lastPage: 3, total: 42 },
+    })
+
+    expect(wrapper.text()).toContain('42 Einträge')
+  })
+
+  it('disables Vorherige button on first page', () => {
+    const wrapper = mount(PaginationControls, {
+      props: { currentPage: 1, lastPage: 3 },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const prev = buttons.find((b) => b.text() === 'Vorherige')
+    expect(prev?.attributes('disabled')).toBeDefined()
+  })
+
+  it('disables Nächste button on last page', () => {
+    const wrapper = mount(PaginationControls, {
+      props: { currentPage: 3, lastPage: 3 },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const next = buttons.find((b) => b.text() === 'Nächste')
+    expect(next?.attributes('disabled')).toBeDefined()
+  })
+
+  it('emits update:currentPage with page - 1 when Vorherige is clicked', async () => {
+    const wrapper = mount(PaginationControls, {
+      props: { currentPage: 3, lastPage: 5 },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const prev = buttons.find((b) => b.text() === 'Vorherige')
+    await prev?.trigger('click')
+
+    expect(wrapper.emitted('update:currentPage')).toEqual([[2]])
+  })
+
+  it('emits update:currentPage with page + 1 when Nächste is clicked', async () => {
+    const wrapper = mount(PaginationControls, {
+      props: { currentPage: 2, lastPage: 5 },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const next = buttons.find((b) => b.text() === 'Nächste')
+    await next?.trigger('click')
+
+    expect(wrapper.emitted('update:currentPage')).toEqual([[3]])
+  })
+})

--- a/frontend/src/components/PaginationControls.vue
+++ b/frontend/src/components/PaginationControls.vue
@@ -1,0 +1,39 @@
+<template>
+  <div v-if="lastPage > 1" class="flex items-center justify-between px-2 py-3">
+    <p class="text-sm text-gray-700 dark:text-gray-300">
+      Seite <span class="font-medium">{{ currentPage }}</span> von
+      <span class="font-medium">{{ lastPage }}</span>
+      <template v-if="total !== undefined">
+        &nbsp;({{ total }} Einträge)
+      </template>
+    </p>
+    <div class="flex gap-2">
+      <button
+        class="btn btn-secondary"
+        :disabled="currentPage <= 1"
+        @click="emit('update:currentPage', currentPage - 1)"
+      >
+        Vorherige
+      </button>
+      <button
+        class="btn btn-secondary"
+        :disabled="currentPage >= lastPage"
+        @click="emit('update:currentPage', currentPage + 1)"
+      >
+        Nächste
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  currentPage: number
+  lastPage: number
+  total?: number
+}>()
+
+const emit = defineEmits<{
+  'update:currentPage': [page: number]
+}>()
+</script>

--- a/frontend/src/composables/usePagination.test.ts
+++ b/frontend/src/composables/usePagination.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { usePagination } from '@/composables/usePagination'
+
+describe('usePagination', () => {
+  it('initializes with page 1 and lastPage 1', () => {
+    const { currentPage, lastPage, total, perPage } = usePagination()
+
+    expect(currentPage.value).toBe(1)
+    expect(lastPage.value).toBe(1)
+    expect(total.value).toBe(0)
+    expect(perPage.value).toBe(15)
+  })
+
+  it('updateFromMeta sets all pagination values', () => {
+    const { currentPage, lastPage, total, perPage, updateFromMeta } = usePagination()
+
+    updateFromMeta({ current_page: 3, last_page: 7, total: 100, per_page: 15 })
+
+    expect(currentPage.value).toBe(3)
+    expect(lastPage.value).toBe(7)
+    expect(total.value).toBe(100)
+    expect(perPage.value).toBe(15)
+  })
+
+  it('setPage updates currentPage', () => {
+    const { currentPage, setPage } = usePagination()
+
+    setPage(5)
+
+    expect(currentPage.value).toBe(5)
+  })
+
+  it('resetPage resets currentPage to 1', () => {
+    const { currentPage, setPage, resetPage } = usePagination()
+
+    setPage(4)
+    expect(currentPage.value).toBe(4)
+
+    resetPage()
+    expect(currentPage.value).toBe(1)
+  })
+
+  it('each call to usePagination returns independent state', () => {
+    const a = usePagination()
+    const b = usePagination()
+
+    a.setPage(3)
+
+    expect(a.currentPage.value).toBe(3)
+    expect(b.currentPage.value).toBe(1)
+  })
+})

--- a/frontend/src/composables/usePagination.ts
+++ b/frontend/src/composables/usePagination.ts
@@ -1,0 +1,40 @@
+import { ref } from 'vue'
+
+export interface PaginationMeta {
+  current_page: number
+  last_page: number
+  total: number
+  per_page: number
+}
+
+export function usePagination() {
+  const currentPage = ref(1)
+  const lastPage = ref(1)
+  const total = ref(0)
+  const perPage = ref(15)
+
+  function updateFromMeta(meta: PaginationMeta): void {
+    currentPage.value = meta.current_page
+    lastPage.value = meta.last_page
+    total.value = meta.total
+    perPage.value = meta.per_page
+  }
+
+  function setPage(page: number): void {
+    currentPage.value = page
+  }
+
+  function resetPage(): void {
+    currentPage.value = 1
+  }
+
+  return {
+    currentPage,
+    lastPage,
+    total,
+    perPage,
+    updateFromMeta,
+    setPage,
+    resetPage,
+  }
+}

--- a/frontend/src/views/bookings/BookingsView.vue
+++ b/frontend/src/views/bookings/BookingsView.vue
@@ -3,7 +3,7 @@
     <!-- Header Actions -->
     <div class="flex justify-between items-center">
       <div class="flex gap-4">
-        <select v-model="filterStatus" @change="loadBookings" class="input max-w-xs">
+        <select v-model="filterStatus" @change="onFilterChange" class="input max-w-xs">
           <option :value="null">Alle Buchungen</option>
           <option value="confirmed">Bestätigt</option>
           <option value="pending">Ausstehend</option>
@@ -129,6 +129,15 @@
       </div>
     </div>
 
+    <!-- Pagination -->
+    <PaginationControls
+      v-if="!loading"
+      :current-page="currentPage"
+      :last-page="lastPage"
+      :total="total"
+      @update:current-page="goToPage"
+    />
+
     <!-- Booking Form Modal (trainer only) -->
     <BookingFormModal
       v-if="isTrainer"
@@ -165,8 +174,10 @@
 import { ref, onMounted, computed } from 'vue'
 import apiClient from '@/api/client'
 import BookingFormModal from '@/components/BookingFormModal.vue'
+import PaginationControls from '@/components/PaginationControls.vue'
 import { handleApiError, showSuccess } from '@/utils/errorHandler'
 import { useAuthStore } from '@/stores/auth'
+import { usePagination } from '@/composables/usePagination'
 
 const authStore = useAuthStore()
 const isCustomer = computed(() => authStore.user?.role === 'customer')
@@ -179,6 +190,8 @@ const showFormModal = ref(false)
 const selectedBooking = ref<any>(null)
 const showDeadlineModal = ref(false)
 
+const { currentPage, lastPage, total, updateFromMeta, resetPage } = usePagination()
+
 onMounted(() => {
   loadBookings()
 })
@@ -186,18 +199,31 @@ onMounted(() => {
 async function loadBookings() {
   loading.value = true
   try {
-    const params: any = {}
+    const params: any = { page: currentPage.value }
     if (filterStatus.value) {
       params.status = filterStatus.value
     }
     
     const response = await apiClient.get('/api/v1/bookings', { params })
     bookings.value = response.data.data
+    if (response.data.meta) {
+      updateFromMeta(response.data.meta)
+    }
   } catch (error) {
     console.error('Error loading bookings:', error)
   } finally {
     loading.value = false
   }
+}
+
+function goToPage(page: number): void {
+  currentPage.value = page
+  loadBookings()
+}
+
+function onFilterChange(): void {
+  resetPage()
+  loadBookings()
 }
 
 function openCreateModal() {

--- a/frontend/src/views/courses/CoursesView.vue
+++ b/frontend/src/views/courses/CoursesView.vue
@@ -8,7 +8,7 @@
           placeholder="Kurse suchen..."
           class="flex-1"
         />
-        <select v-model="filterStatus" @change="loadCourses" class="input max-w-xs">
+        <select v-model="filterStatus" @change="onFilterChange" class="input max-w-xs">
           <option :value="null">Alle Kurse</option>
           <option value="active">Aktive Kurse</option>
           <option value="planned">Geplante Kurse</option>
@@ -113,6 +113,15 @@
       </div>
     </div>
 
+    <!-- Pagination -->
+    <PaginationControls
+      v-if="!loading"
+      :current-page="currentPage"
+      :last-page="lastPage"
+      :total="total"
+      @update:current-page="goToPage"
+    />
+
     <!-- Course Form Modal -->
     <CourseFormModal 
       :is-open="showFormModal" 
@@ -138,9 +147,11 @@ import apiClient from '@/api/client'
 import CourseFormModal from '@/components/CourseFormModal.vue'
 import CustomerBookingModal from '@/components/CustomerBookingModal.vue'
 import SearchInput from '@/components/SearchInput.vue'
+import PaginationControls from '@/components/PaginationControls.vue'
 import { useAuthStore } from '@/stores/auth'
 import { handleApiError, showSuccess } from '@/utils/errorHandler'
 import DOMPurify from 'dompurify'
+import { usePagination } from '@/composables/usePagination'
 
 const loading = ref(true)
 const filterStatus = ref<string | null>(null)
@@ -148,6 +159,8 @@ const searchQuery = ref('')
 const courses = ref<any[]>([])
 const showFormModal = ref(false)
 const selectedCourse = ref<any>(null)
+
+const { currentPage, lastPage, total, updateFromMeta, resetPage } = usePagination()
 
 const authStore = useAuthStore()
 const isTrainerOrAdmin = computed(() => authStore.isAuthenticated && authStore.isTrainer)
@@ -165,6 +178,7 @@ onMounted(() => {
 })
 
 watch(searchQuery, () => {
+  resetPage()
   loadCourses()
 })
 
@@ -202,7 +216,7 @@ async function onBookingCompleted(): Promise<void> {
 async function loadCourses() {
   loading.value = true
   try {
-    const params: any = {}
+    const params: any = { page: currentPage.value }
     if (filterStatus.value) {
       params.status = filterStatus.value
     }
@@ -212,12 +226,25 @@ async function loadCourses() {
     
     const response = await apiClient.get('/api/v1/courses', { params })
     courses.value = response.data.data || []
+    if (response.data.meta) {
+      updateFromMeta(response.data.meta)
+    }
   } catch (error) {
     handleApiError(error, 'Fehler beim Laden der Kurse')
     courses.value = []
   } finally {
     loading.value = false
   }
+}
+
+function goToPage(page: number): void {
+  currentPage.value = page
+  loadCourses()
+}
+
+function onFilterChange(): void {
+  resetPage()
+  loadCourses()
 }
 
 function openCreateModal() {

--- a/frontend/src/views/customers/CustomersView.vue
+++ b/frontend/src/views/customers/CustomersView.vue
@@ -73,6 +73,15 @@
       </div>
     </div>
 
+    <!-- Pagination -->
+    <PaginationControls
+      v-if="!loading"
+      :current-page="currentPage"
+      :last-page="lastPage"
+      :total="total"
+      @update:current-page="goToPage"
+    />
+
     <!-- Customer Form Modal -->
     <CustomerFormModal 
       :is-open="showFormModal" 
@@ -97,7 +106,9 @@ import apiClient from '@/api/client'
 import CustomerFormModal from '@/components/CustomerFormModal.vue'
 import CustomerDetailModal from '@/components/CustomerDetailModal.vue'
 import SearchInput from '@/components/SearchInput.vue'
+import PaginationControls from '@/components/PaginationControls.vue'
 import { handleApiError, showSuccess } from '@/utils/errorHandler'
+import { usePagination } from '@/composables/usePagination'
 
 const loading = ref(true)
 const searchQuery = ref('')
@@ -106,29 +117,40 @@ const showFormModal = ref(false)
 const showDetailModal = ref(false)
 const selectedCustomer = ref<any>(null)
 
+const { currentPage, lastPage, total, updateFromMeta, resetPage } = usePagination()
+
 onMounted(() => {
   loadCustomers()
 })
 
 watch(searchQuery, () => {
+  resetPage()
   loadCustomers()
 })
 
 async function loadCustomers() {
   loading.value = true
   try {
-    const params: any = {}
+    const params: any = { page: currentPage.value }
     if (searchQuery.value) {
       params.search = searchQuery.value
     }
     
     const response = await apiClient.get('/api/v1/customers', { params })
     customers.value = response.data.data
+    if (response.data.meta) {
+      updateFromMeta(response.data.meta)
+    }
   } catch (error) {
     console.error('Error loading customers:', error)
   } finally {
     loading.value = false
   }
+}
+
+function goToPage(page: number): void {
+  currentPage.value = page
+  loadCustomers()
 }
 
 function openCreateModal() {

--- a/frontend/src/views/dogs/DogsView.vue
+++ b/frontend/src/views/dogs/DogsView.vue
@@ -82,6 +82,15 @@
       </div>
     </div>
 
+    <!-- Pagination -->
+    <PaginationControls
+      v-if="!loading"
+      :current-page="currentPage"
+      :last-page="lastPage"
+      :total="total"
+      @update:current-page="goToPage"
+    />
+
     <!-- Dog Form Modal -->
     <DogFormModal
       :is-open="showFormModal"
@@ -107,7 +116,9 @@ import DogFormModal from '@/components/DogFormModal.vue'
 import CustomerDogRequestModal from '@/components/CustomerDogRequestModal.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import SearchInput from '@/components/SearchInput.vue'
+import PaginationControls from '@/components/PaginationControls.vue'
 import { handleApiError, showSuccess } from '@/utils/errorHandler'
+import { usePagination } from '@/composables/usePagination'
 
 const authStore = useAuthStore()
 const user = computed(() => authStore.user)
@@ -119,29 +130,40 @@ const showFormModal = ref(false)
 const selectedDog = ref<any>(null)
 const showCustomerRequestModal = ref(false)
 
+const { currentPage, lastPage, total, updateFromMeta, resetPage } = usePagination()
+
 onMounted(() => {
   loadDogs()
 })
 
 watch(searchQuery, () => {
+  resetPage()
   loadDogs()
 })
 
 async function loadDogs() {
   loading.value = true
   try {
-    const params: any = {}
+    const params: any = { page: currentPage.value }
     if (searchQuery.value) {
       params.search = searchQuery.value
     }
     
     const response = await apiClient.get('/api/v1/dogs', { params })
     dogs.value = response.data.data
+    if (response.data.meta) {
+      updateFromMeta(response.data.meta)
+    }
   } catch (error) {
     console.error('Error loading dogs:', error)
   } finally {
     loading.value = false
   }
+}
+
+function goToPage(page: number): void {
+  currentPage.value = page
+  loadDogs()
 }
 
 function openCreateModal() {

--- a/frontend/src/views/invoices/InvoicesView.vue
+++ b/frontend/src/views/invoices/InvoicesView.vue
@@ -3,7 +3,7 @@
     <!-- Header Actions -->
     <div class="flex justify-between items-center">
       <div class="flex gap-4">
-        <select v-model="filterStatus" @change="loadInvoices" class="input max-w-xs">
+        <select v-model="filterStatus" @change="onFilterChange" class="input max-w-xs">
           <option :value="null">Alle Rechnungen</option>
           <option value="draft">Entwurf</option>
           <option value="sent">Versendet</option>
@@ -82,6 +82,15 @@
       </div>
     </div>
 
+    <!-- Pagination -->
+    <PaginationControls
+      v-if="!loading"
+      :current-page="currentPage"
+      :last-page="lastPage"
+      :total="total"
+      @update:current-page="goToPage"
+    />
+
     <!-- Invoice Form Modal -->
     <InvoiceFormModal 
       :is-open="showFormModal" 
@@ -107,8 +116,10 @@ import { ref, onMounted } from 'vue'
 import apiClient from '@/api/client'
 import InvoiceFormModal from '@/components/InvoiceFormModal.vue'
 import InvoiceDetailModal from '@/components/InvoiceDetailModal.vue'
+import PaginationControls from '@/components/PaginationControls.vue'
 import { handleApiError, showSuccess } from '@/utils/errorHandler'
 import { useAuthStore } from '@/stores/auth'
+import { usePagination } from '@/composables/usePagination'
 
 const authStore = useAuthStore()
 
@@ -119,6 +130,8 @@ const showFormModal = ref(false)
 const showDetailModal = ref(false)
 const selectedInvoice = ref<any>(null)
 
+const { currentPage, lastPage, total, updateFromMeta, resetPage } = usePagination()
+
 onMounted(() => {
   loadInvoices()
 })
@@ -126,18 +139,31 @@ onMounted(() => {
 async function loadInvoices() {
   loading.value = true
   try {
-    const params: any = {}
+    const params: any = { page: currentPage.value }
     if (filterStatus.value) {
       params.status = filterStatus.value
     }
     
     const response = await apiClient.get('/api/v1/invoices', { params })
     invoices.value = response.data.data
+    if (response.data.meta) {
+      updateFromMeta(response.data.meta)
+    }
   } catch (error) {
     console.error('Error loading invoices:', error)
   } finally {
     loading.value = false
   }
+}
+
+function goToPage(page: number): void {
+  currentPage.value = page
+  loadInvoices()
+}
+
+function onFilterChange(): void {
+  resetPage()
+  loadInvoices()
 }
 
 function openCreateModal() {


### PR DESCRIPTION
Closes #44

## Änderungen

### Neue Dateien
- **`PaginationControls.vue`** — Wiederverwendbare Pagination-Komponente: "Seite X von Y · Vorherige / Nächste". Rendert sich selbst weg wenn `lastPage <= 1`.
- **`usePagination.ts`** — Composable mit `currentPage`, `lastPage`, `total`, `perPage`, `updateFromMeta()`, `setPage()`, `resetPage()`.
- **`PaginationControls.test.ts`** + **`usePagination.test.ts`** — Vitest-Tests (12 neue Tests)

### Geänderte Views
Alle 5 betroffenen Views wurden identisch erweitert:
- **CoursesView, BookingsView, DogsView, CustomersView, InvoicesView**
  - `usePagination` eingebunden
  - `page`-Parameter wird an alle API-Aufrufe übergeben
  - `PaginationControls` unterhalb der Liste eingefügt
  - Filter/Suche rufen `resetPage()` vor dem Reload auf

## Tests
```
Test Files  9 passed (9)
Tests  106 passed (106)
```
Build: ✓ ohne Warnings