### PR TITLE
fix: Favicon-Upload akzeptiert .ico-Dateien und Formular bleibt nach …

### DIFF
--- a/backend/app/Http/Requests/UpdateSettingsRequest.php
+++ b/backend/app/Http/Requests/UpdateSettingsRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -24,7 +25,7 @@ class UpdateSettingsRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
@@ -42,13 +43,13 @@ class UpdateSettingsRequest extends FormRequest
             'company_registration_number' => ['sometimes', 'nullable', 'string', 'max:50'],
             'company_small_business' => ['sometimes', 'nullable', 'in:true,false,1,0'],
             'company_logo' => ['sometimes', 'nullable', 'image', 'max:2048', 'mimes:png,jpg,jpeg,svg'],
-            'company_favicon' => ['sometimes', 'nullable', 'image', 'max:512', 'mimes:png,ico'],
+            'company_favicon' => ['sometimes', 'nullable', 'file', 'max:512', 'mimes:png,ico'],
 
             // Email settings
             'email_from_address' => ['sometimes', 'nullable', 'email', 'max:255'],
             'email_from_name' => ['sometimes', 'nullable', 'string', 'max:255'],
             'email_driver' => ['sometimes', 'nullable', 'string', 'in:smtp,sendmail,mailgun,ses,postmark,log'],
-            
+
             // SMTP settings
             'smtp_host' => ['sometimes', 'nullable', 'string', 'max:255'],
             'smtp_port' => ['sometimes', 'nullable', 'integer', 'min:1', 'max:65535'],

--- a/backend/tests/Feature/Api/SettingsValidationTest.php
+++ b/backend/tests/Feature/Api/SettingsValidationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+uses()->group('api', 'setting');
+
+beforeEach(function () {
+    Storage::fake('public');
+    $this->admin = User::factory()->admin()->create();
+});
+
+// ======== company_favicon — ICO akzeptiert ========
+
+it('akzeptiert eine ico-datei als company_favicon', function () {
+    $favicon = UploadedFile::fake()->create('favicon.ico', 100, 'image/x-icon');
+
+    $this->actingAs($this->admin)
+        ->putJson('/api/v1/settings', [
+            'company_favicon' => $favicon,
+        ])
+        ->assertOk();
+});
+
+it('akzeptiert eine ico-datei mit mime-typ image/vnd.microsoft.icon als company_favicon', function () {
+    $favicon = UploadedFile::fake()->create('favicon.ico', 100, 'image/vnd.microsoft.icon');
+
+    $this->actingAs($this->admin)
+        ->putJson('/api/v1/settings', [
+            'company_favicon' => $favicon,
+        ])
+        ->assertOk();
+});
+
+// ======== company_favicon — PNG akzeptiert ========
+
+it('akzeptiert eine png-datei als company_favicon', function () {
+    $favicon = UploadedFile::fake()->image('favicon.png');
+
+    $this->actingAs($this->admin)
+        ->putJson('/api/v1/settings', [
+            'company_favicon' => $favicon,
+        ])
+        ->assertOk();
+});
+
+// ======== company_favicon — unerlaubter MIME-Typ abgelehnt ========
+
+it('weist eine exe-datei als company_favicon zurück', function () {
+    $file = UploadedFile::fake()->create('favicon.exe', 100, 'application/x-msdownload');
+
+    $this->actingAs($this->admin)
+        ->putJson('/api/v1/settings', [
+            'company_favicon' => $file,
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['company_favicon']);
+});
+
+// ======== company_favicon — Datei über 512 KB abgelehnt ========
+
+it('weist eine datei über 512 kb als company_favicon zurück', function () {
+    $oversized = UploadedFile::fake()->create('big.ico', 513, 'image/x-icon');
+
+    $this->actingAs($this->admin)
+        ->putJson('/api/v1/settings', [
+            'company_favicon' => $oversized,
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['company_favicon']);
+});
+
+// ======== company_favicon — fehlendes Feld löst keinen Fehler aus ========
+
+it('verursacht keinen validierungsfehler wenn company_favicon nicht gesendet wird', function () {
+    $this->actingAs($this->admin)
+        ->putJson('/api/v1/settings', [
+            'company_name' => 'Musterhundeschule',
+        ])
+        ->assertOk();
+});
+
+// ======== company_logo — image-Regel bleibt unberührt ========
+
+it('akzeptiert weiterhin eine png-datei als company_logo', function () {
+    $logo = UploadedFile::fake()->image('logo.png');
+
+    $this->actingAs($this->admin)
+        ->putJson('/api/v1/settings', [
+            'company_logo' => $logo,
+        ])
+        ->assertOk();
+});

--- a/frontend/src/views/SettingsView.test.ts
+++ b/frontend/src/views/SettingsView.test.ts
@@ -1,0 +1,143 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import SettingsView from '@/views/SettingsView.vue'
+import { settingsApi } from '@/api/settings'
+
+// --- Mock: Settings API ---
+vi.mock('@/api/settings', () => ({
+  settingsApi: {
+    getSettings: vi.fn(),
+    updateSettings: vi.fn(),
+  },
+}))
+
+// --- Mock: Pricing composable (außerhalb des Test-Fokus) ---
+vi.mock('@/composables/usePricingItems', () => ({
+  usePricingItems: () => ({
+    items: [],
+    loading: false,
+    error: null,
+    loadAll: vi.fn().mockResolvedValue(undefined),
+    deleteItem: vi.fn().mockResolvedValue(undefined),
+    groups: [],
+  }),
+}))
+
+// --- Stubs für Unter-Komponenten mit eigenen Abhängigkeiten ---
+const globalStubs = {
+  EmailTemplateEditor: { template: '<div data-testid="email-template-editor" />' },
+  PricingItemForm: { template: '<div data-testid="pricing-item-form" />' },
+}
+
+/** Minimale gültige API-Antwort für getSettings */
+const mockSettingsResponse = {
+  data: { company: [], email: [], general: [] },
+}
+
+/** Erstellt und mounted SettingsView mit globalen Stubs */
+function mountView() {
+  return mount(SettingsView, {
+    global: { stubs: globalStubs },
+  })
+}
+
+// --- Tests ---
+describe('SettingsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ------------------------------------------------------------------ //
+  // Formular-Sichtbarkeit nach Speicherfehler                            //
+  // ------------------------------------------------------------------ //
+  describe('Speicherfehler lässt Formular sichtbar', () => {
+    it('zeigt das Formular nach einem 422-Fehler beim Speichern weiterhin an', async () => {
+      vi.mocked(settingsApi.getSettings).mockResolvedValue(mockSettingsResponse)
+      vi.mocked(settingsApi.updateSettings).mockRejectedValue(
+        Object.assign(new Error('Unprocessable Entity'), {
+          response: { status: 422, data: { message: 'Ungültige Eingabe.' } },
+        }),
+      )
+
+      const wrapper = mountView()
+      await flushPromises() // loadSettings abwarten → Formular sichtbar
+
+      await wrapper.find('form').trigger('submit')
+      await flushPromises() // updateSettings schlägt fehl
+
+      expect(wrapper.find('form').exists()).toBe(true)
+    })
+
+    it('zeigt die saveError-Meldung unterhalb der Buttons an', async () => {
+      vi.mocked(settingsApi.getSettings).mockResolvedValue(mockSettingsResponse)
+      vi.mocked(settingsApi.updateSettings).mockRejectedValue(
+        Object.assign(new Error('Unprocessable Entity'), {
+          response: { status: 422, data: { message: 'Ungültige Eingabe.' } },
+        }),
+      )
+
+      const wrapper = mountView()
+      await flushPromises()
+
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('Ungültige Eingabe.')
+    })
+
+    it('setzt saveError beim nächsten Speicherversuch zurück', async () => {
+      vi.mocked(settingsApi.getSettings).mockResolvedValue(mockSettingsResponse)
+      vi.mocked(settingsApi.updateSettings)
+        .mockRejectedValueOnce(
+          Object.assign(new Error('Unprocessable Entity'), {
+            response: { status: 422, data: { message: 'Ungültige Eingabe.' } },
+          }),
+        )
+        .mockResolvedValueOnce({ data: {}, message: 'Gespeichert.' } as any)
+
+      const wrapper = mountView()
+      await flushPromises()
+
+      // Erster Speicherversuch → Fehler erscheint
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+      expect(wrapper.text()).toContain('Ungültige Eingabe.')
+
+      // Zweiter Speicherversuch → Fehler wird zurückgesetzt
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+      expect(wrapper.text()).not.toContain('Ungültige Eingabe.')
+    })
+  })
+
+  // ------------------------------------------------------------------ //
+  // Ladefehler blendet Formular aus                                      //
+  // ------------------------------------------------------------------ //
+  describe('Ladefehler blendet Formular aus', () => {
+    it('versteckt das Formular bei einem 500-Fehler in loadSettings', async () => {
+      vi.mocked(settingsApi.getSettings).mockRejectedValue(
+        Object.assign(new Error('Internal Server Error'), {
+          response: { status: 500, data: { message: 'Interner Serverfehler.' } },
+        }),
+      )
+
+      const wrapper = mountView()
+      await flushPromises()
+
+      expect(wrapper.find('form').exists()).toBe(false)
+    })
+
+    it('zeigt die loadError-Meldung an wenn das Laden fehlschlägt', async () => {
+      vi.mocked(settingsApi.getSettings).mockRejectedValue(
+        Object.assign(new Error('Internal Server Error'), {
+          response: { status: 500, data: { message: 'Interner Serverfehler.' } },
+        }),
+      )
+
+      const wrapper = mountView()
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('Interner Serverfehler.')
+    })
+  })
+})

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -12,9 +12,9 @@
       <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
     </div>
 
-    <!-- Error State -->
-    <div v-else-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
-      <p class="text-red-800">{{ error }}</p>
+    <!-- Load Error State -->
+    <div v-else-if="loadError" class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+      <p class="text-red-800">{{ loadError }}</p>
     </div>
 
     <!-- Settings Form -->
@@ -382,6 +382,14 @@
       >
         <p class="text-green-800">{{ successMessage }}</p>
       </div>
+
+      <!-- Save Error Message -->
+      <div
+        v-if="saveError"
+        class="bg-red-50 border border-red-200 rounded-lg p-4"
+      >
+        <p class="text-red-800">{{ saveError }}</p>
+      </div>
     </form>
 
     <!-- Preise-Abschnitt -->
@@ -554,7 +562,8 @@ const formData = ref({
 
 const loading = ref(false)
 const saving = ref(false)
-const error = ref<string | null>(null)
+const loadError = ref<string | null>(null)
+const saveError = ref<string | null>(null)
 const successMessage = ref<string | null>(null)
 const logoPreview = ref<string | null>(null)
 const faviconPreview = ref<string | null>(null)
@@ -564,7 +573,7 @@ const faviconPreview = ref<string | null>(null)
  */
 const loadSettings = async () => {
   loading.value = true
-  error.value = null
+  loadError.value = null
 
   try {
     const response = await settingsApi.getSettings()
@@ -596,7 +605,7 @@ const loadSettings = async () => {
       }
     })
   } catch (err: any) {
-    error.value = err.response?.data?.message || 'Fehler beim Laden der Einstellungen.'
+    loadError.value = err.response?.data?.message || 'Fehler beim Laden der Einstellungen.'
     console.error('Error loading settings:', err)
   } finally {
     loading.value = false
@@ -608,7 +617,7 @@ const loadSettings = async () => {
  */
 const saveSettings = async () => {
   saving.value = true
-  error.value = null
+  saveError.value = null
   successMessage.value = null
 
   try {
@@ -640,7 +649,7 @@ const saveSettings = async () => {
       successMessage.value = null
     }, 5000)
   } catch (err: any) {
-    error.value = err.response?.data?.message || 'Fehler beim Speichern der Einstellungen.'
+    saveError.value = err.response?.data?.message || 'Fehler beim Speichern der Einstellungen.'
     console.error('Error saving settings:', err)
   } finally {
     saving.value = false

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/acceptance.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/acceptance.md
@@ -1,0 +1,63 @@
+# Abnahme: favicon-ico-upload-bug
+
+**Status:** bereit-für-user-review
+
+---
+
+## Erfüllt
+
+### T01 — Backend-Validierungsfix
+
+- `UpdateSettingsRequest.php:46`: Regel `file` ist gesetzt (verifiziert per grep). `company_logo` hat `image` unverändert behalten — kein Seiteneffekt.
+- Testdatei liegt in `backend/tests/Feature/Api/SettingsValidationTest.php` (Reviewer-Sollte-Befund: Verschieben in Api/-Unterverzeichnis — erledigt).
+- 7 Pest-Tests, alle grün (658/658 Gesamtsuite). Abdeckung: `image/x-icon`, `image/vnd.microsoft.icon` (vom Tester ergänzt), PNG, EXE-Ablehnung, Übergröße, fehlendes Feld, Logo-Seiteneffektschutz.
+- Alle 8 Akzeptanzkriterien aus `tasks.md` abgehakt.
+- PHP-8.2-Kompatibilität eingehalten; `composer qa` grün (inkl. Pint-Stylefixup für FQCN-Import, keine logische Änderung).
+- Reviewer: ok, keine Muss-Befunde.
+- Reviewer-Könnte-Befund (vnd.microsoft.icon-Test) wurde vom Tester proaktiv aufgegriffen und umgesetzt.
+
+### T02 — Frontend-State-Refactoring
+
+- `const error` vollständig entfernt (kein verbleibender Verweis im Template oder Script).
+- `const loadError` (Zeile 565) und `const saveError` (Zeile 566) korrekt deklariert.
+- Template: `v-else-if="loadError"` auf Zeile 16; `v-if="saveError"`-Block auf Zeile 388 innerhalb `<form v-else>` — visuell konsistent mit `successMessage`-Block.
+- Beide catch-Zweige befüllen die korrekte Ref (`loadSettings` → `loadError.value`, `saveSettings` → `saveError.value`); Reset jeweils am Funktionsanfang (`loadError.value = null` Z. 576, `saveError.value = null` Z. 620).
+- 5 Vitest-Tests: 72/72 Gesamtsuite grün. Szenarien: 422-Fehler lässt Formular im DOM, `saveError`-Meldung erscheint, Reset beim Folgeversuch, 500-Fehler versteckt Formular, `loadError`-Meldung erscheint.
+- `npm run build` erfolgreich, keine Warnings.
+- Reviewer: ok, keine Muss- oder Sollte-Befunde.
+
+### Spec-Konformität (`specs/settings-favicon-upload/spec.md`)
+
+Alle 8 Spec-Szenarien sind durch Tests oder Code-Inspektion nachgewiesen:
+- "ICO-Datei wird hochgeladen" (`image/x-icon` + `image/vnd.microsoft.icon`) — zwei Tests.
+- "PNG-Datei wird hochgeladen" — ein Test.
+- "Unerlaubter MIME-Typ wird abgelehnt" — EXE-Test (422).
+- "Datei zu groß" — 513-KB-Test (422).
+- "Kein Favicon gesendet" — `sometimes`-Test.
+- "Speicherfehler durch Validierung — Formular bleibt sichtbar" — Vitest-Test 1 + 2.
+- "Ladefehler hält Formular ausgeblendet" — Vitest-Test 4 + 5.
+- "Speicherfehler-Meldung verschwindet bei erneutem Versuch" — Vitest-Test 3.
+
+---
+
+## Offen / Nacharbeit
+
+Keine offenen Punkte.
+
+---
+
+## Lint-Klarstellung
+
+Das `lint`-Script existiert im Frontend-Projekt nicht (`frontend/package.json`
+definiert kein `lint`-Script, kein ESLint konfiguriert). Dies wurde von Tester
+und Reviewer bereits dokumentiert. Der de-facto Qualitätscheck ist `npm run build`
+(läuft `vue-tsc -b` + Vite), der grün ist. Das Akzeptanzkriterium `npm run lint`
+ist für dieses Projekt eine tote Regel — nicht erfüllbar, nicht blockend.
+
+---
+
+## Empfehlung an den User
+
+**Freigabe erteilt.** Der Change ist vollständig und bereit für User-Gate 2.
+Beide Bugs korrekt behoben, alle Tests grün (7 Backend, 72 Frontend),
+alle Spec-Szenarien abgedeckt, keine offenen Befunde.

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/design.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/design.md
@@ -1,0 +1,161 @@
+# Design: favicon-ico-upload-bug
+
+## Architekturübersicht
+
+Beide Fixes sind unabhängig voneinander und berühren keine gemeinsamen Module.
+T01 (Backend) kann parallel zu T02 (Frontend) bearbeitet werden. Es gibt keine
+Abhängigkeit zwischen den Tasks.
+
+---
+
+## Bug 1 — Backend: `image`-Regel erlaubt kein ICO
+
+### Analyse
+
+**Datei:** `backend/app/Http/Requests/UpdateSettingsRequest.php`, Zeile 45
+
+Aktuelle Regel:
+```php
+'company_favicon' => ['sometimes', 'nullable', 'image', 'max:512', 'mimes:png,ico'],
+```
+
+Laravels `image`-Validator (`Illuminate\Validation\Concerns\ValidatesAttributes::validateImage`)
+prüft den MIME-Typ via `finfo` und erlaubt ausschließlich:
+`image/jpeg`, `image/png`, `image/gif`, `image/bmp`, `image/svg+xml`, `image/webp`.
+
+`image/x-icon` und `image/vnd.microsoft.icon` (beide MIME-Typen für ICO) sind
+dort nicht aufgeführt. Die danebenstehende Regel `mimes:png,ico` wird nie
+erreicht, weil `image` zuerst fehlschlägt.
+
+### Fix
+
+`image` durch `file` ersetzen. `file` prüft nur, dass es sich um eine gültige
+hochgeladene Datei handelt — die inhaltliche Einschränkung auf PNG und ICO
+übernimmt anschließend `mimes:png,ico`.
+
+```php
+// vorher
+'company_favicon' => ['sometimes', 'nullable', 'image', 'max:512', 'mimes:png,ico'],
+
+// nachher
+'company_favicon' => ['sometimes', 'nullable', 'file',  'max:512', 'mimes:png,ico'],
+```
+
+### Kompatibilitätsprüfung
+
+- **PHP-Kompatibilität:** Reiner Laravel-Validator-Regelname — keine PHP-Syntax-
+  spezifischen Features. Kompatibel mit PHP 8.2+.
+- **DB-Kompatibilität:** keine DB-Änderung.
+- **Shared-Hosting:** keine Auswirkung.
+
+### Abgrenzung: `company_logo` bleibt unverändert
+
+`company_logo` hat weiterhin `['sometimes', 'nullable', 'image', 'max:2048', 'mimes:png,jpg,jpeg,svg']`
+(Zeile 44). Dort ist `image` korrekt, da PNG/JPG/JPEG/SVG alle von Laravels
+`image`-Regel erkannt werden.
+
+---
+
+## Bug 2 — Frontend: Formular verschwindet nach Speicherfehler
+
+### Analyse
+
+**Datei:** `frontend/src/views/SettingsView.vue`
+
+Template-Conditional (Zeilen 11–21):
+```html
+<div v-if="loading">…</div>
+<div v-else-if="error">…</div>   <!-- blockt das Formular -->
+<form v-else>…</form>
+```
+
+Reactive State (Zeile 557):
+```ts
+const error = ref<string | null>(null)
+```
+
+`loadSettings()` schreibt bei Netzwerk-/API-Fehlern in `error.value`
+(Zeile 599). `saveSettings()` schreibt ebenfalls in `error.value` bei einem
+422-Fehler (Zeile 643). Da beide dieselbe Ref benutzen, schaltet jeder
+Speicherfehler das `v-else-if="error"` auf `true` — das Formular fällt weg.
+
+### Fix: zwei getrennte Refs
+
+Bestehende `error`-Ref wird umbenannt und ihre Nutzung aufgeteilt:
+
+| Alter Name | Neuer Name | Verwendung |
+|------------|------------|------------|
+| `error` (in `loadSettings()`) | `loadError` | Steuert Sichtbarkeit des Formulars |
+| `error` (in `saveSettings()`) | `saveError` | Inline-Fehlermeldung im Formular |
+
+**Template-Anpassungen:**
+
+```html
+<!-- Loading State — unverändert -->
+<div v-if="loading">…</div>
+
+<!-- Load-Error State — zeigt nur Ladefehler, kein Speicherfehler -->
+<div v-else-if="loadError" class="bg-red-50 border border-red-200 …">
+  <p class="text-red-800">{{ loadError }}</p>
+</div>
+
+<!-- Settings Form — sichtbar sobald kein Ladefehler -->
+<form v-else @submit.prevent="saveSettings">
+  …
+  <!-- Speicherfehler inline im Formular, unterhalb der Buttons -->
+  <div v-if="saveError" class="bg-red-50 border border-red-200 …">
+    <p class="text-red-800">{{ saveError }}</p>
+  </div>
+  …
+</form>
+```
+
+**Script-Anpassungen:**
+
+1. `const error = ref<string | null>(null)` entfernen.
+2. `const loadError = ref<string | null>(null)` und
+   `const saveError = ref<string | null>(null)` hinzufügen.
+3. In `loadSettings()`: alle `error.value`-Zuweisungen auf `loadError.value`.
+4. In `saveSettings()`:
+   - `error.value = null` am Anfang → `saveError.value = null`
+   - Fehler-Catch: `error.value = …` → `saveError.value = …`
+5. Template: alle `error`-Referenzen entsprechend aktualisieren.
+
+### Platzierung des `saveError`-Blocks
+
+Der `saveError`-Block wird direkt unterhalb des vorhandenen
+`successMessage`-Blocks (Zeilen 379–384) eingefügt. Damit folgt er dem
+etablierten Muster (grüne Box für Erfolg, rote Box für Fehler) und bleibt
+konsistent mit dem Rest der Seite.
+
+### Kompatibilitätsprüfung
+
+- Rein lokale State-Änderung in einer SFC. Kein API-Vertrag betroffen.
+- Keine neuen Abhängigkeiten.
+- `npm run build` muss weiter fehlerfrei durchlaufen.
+
+---
+
+## Entwurfsmuster-Bezug
+
+- **Single Responsibility (SOLID-S):** Jede Ref hat eine eindeutige
+  Verantwortung — Ladefehlerstatus vs. Speicherfehlerstatus.
+- **KISS:** Minimaler Eingriff; keine neue Abstraktion, nur eine saubere
+  Benennung vorhandener State-Variablen.
+- **DRY:** Kein doppelter Fehleranzeigeblock; das Template-Conditional für
+  Ladefehler bleibt ein einziger Block.
+
+---
+
+## Sequenz beim Speicherfehler (nach Fix)
+
+```
+User klickt Speichern
+  → saveSettings() setzt saveError.value = null
+  → API-Call schlägt fehl (z. B. 422)
+  → saveError.value = "Fehler beim Speichern…"
+  → loadError bleibt null
+  → v-else-if="loadError" ist false
+  → Formular (v-else) bleibt im DOM
+  → saveError-Block unterhalb der Buttons wird sichtbar
+```

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/proposal.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/proposal.md
@@ -1,0 +1,50 @@
+# Proposal: favicon-ico-upload-bug
+
+**Change-ID:** favicon-ico-upload-bug
+**Typ:** Bugfix
+**Pfad:** klein
+**Status:** entwurf
+
+---
+
+## Was wird geändert?
+
+Zwei zusammenhängende Bugs im Bereich Systemeinstellungen werden behoben:
+
+1. **Validation-Bug (Backend):** Der Admin kann kein `.ico`-Favicon hochladen,
+   obwohl die UI diese Endung bewirbt. Laravel lehnt ICO-Dateien mit der
+   Fehlermeldung "The Favicon field must be an image." ab.
+
+2. **Template-Bug (Frontend):** Nach jedem Speicherfehler (z. B. dem
+   Validation-Fehler aus Bug 1) verschwindet das gesamte Einstellungsformular
+   und ist erst nach einem Seitenneuladen wieder sichtbar. Nur der
+   Preise-Abschnitt bleibt erreichbar.
+
+---
+
+## Warum wird es geändert?
+
+- Der Admin kann eine beworbene Funktion (Favicon-Upload als ICO) nicht nutzen.
+- Jeder Speicherfehler macht das Formular unbedienbar — d. h. auch valide
+  Eingaben können nach einem Fehler nicht mehr gespeichert werden.
+- Beide Bugs entstehen durch unabhängige, lokale Logikfehler und lassen sich
+  ohne Schemaänderungen oder neue Abhängigkeiten beheben.
+
+---
+
+## Umfang
+
+| Bereich | Datei | Art |
+|---------|-------|-----|
+| Backend | `backend/app/Http/Requests/UpdateSettingsRequest.php` | Regelfix (1 Zeile) |
+| Backend | `backend/tests/Feature/SettingsValidationTest.php` | Neu (Pest) |
+| Frontend | `frontend/src/views/SettingsView.vue` | State-Refactoring |
+| Frontend | `frontend/src/views/SettingsView.test.ts` | Neu (Vitest) |
+
+---
+
+## Nicht im Scope
+
+- Kein Schemaumbau, keine Datenbankänderungen.
+- Keine Änderungen an anderen Validierungsregeln (Logo bleibt `image`).
+- Keine visuellen Redesigns; nur die State-Logik und das Template-Conditional werden angepasst.

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/specs/settings-favicon-upload/spec.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/specs/settings-favicon-upload/spec.md
@@ -1,0 +1,69 @@
+# Spec: settings-favicon-upload
+
+**Status:** ADDED
+**Capability:** Favicon-Upload in den Systemeinstellungen
+
+---
+
+## Purpose
+
+Der Admin kann in den Systemeinstellungen ein Favicon hochladen, das als
+`image/x-icon` (`.ico`) oder als `image/png` (`.png`) vorliegen darf.
+Das Backend akzeptiert beide Formate. Das Frontend bleibt nach einem
+Validierungsfehler beim Speichern bedienbar.
+
+---
+
+## ADDED Requirements
+
+### Requirement: Favicon-Dateivalidierung (Backend)
+
+#### Scenario: ICO-Datei wird hochgeladen
+- **GIVEN** ein Admin sendet eine `multipart/form-data`-Anfrage an `PUT /api/v1/settings`
+- **AND** das Feld `company_favicon` enthält eine Datei mit MIME-Typ
+  `image/x-icon` oder `image/vnd.microsoft.icon` und Dateigröße <= 512 KB
+- **THEN** die Anfrage wird akzeptiert (kein Validierungsfehler für `company_favicon`)
+
+#### Scenario: PNG-Datei wird hochgeladen
+- **GIVEN** ein Admin sendet eine `multipart/form-data`-Anfrage an `PUT /api/v1/settings`
+- **AND** das Feld `company_favicon` enthält eine Datei mit MIME-Typ `image/png`
+  und Dateigröße <= 512 KB
+- **THEN** die Anfrage wird akzeptiert
+
+#### Scenario: Unerlaubter MIME-Typ wird abgelehnt
+- **GIVEN** ein Admin sendet eine Datei mit einem anderen MIME-Typ
+  (z. B. `application/octet-stream`, `image/jpeg`)
+- **THEN** die API gibt HTTP 422 zurück mit einem Validierungsfehler
+  für `company_favicon`
+
+#### Scenario: Datei zu groß
+- **GIVEN** ein Admin sendet eine ICO- oder PNG-Datei mit mehr als 512 KB
+- **THEN** die API gibt HTTP 422 zurück mit einem Validierungsfehler
+  für `company_favicon`
+
+#### Scenario: Kein Favicon gesendet
+- **GIVEN** die Anfrage enthält kein Feld `company_favicon`
+- **THEN** die Anfrage wird ohne Fehler für `company_favicon` verarbeitet
+  (`sometimes`-Regel)
+
+---
+
+### Requirement: Formular bleibt nach Speicherfehler sichtbar (Frontend)
+
+#### Scenario: Speicherfehler durch Validierung
+- **GIVEN** das Einstellungsformular ist geladen und sichtbar
+- **WHEN** der Admin auf "Speichern" klickt und das Backend HTTP 422 antwortet
+- **THEN** das `<form>`-Element bleibt im DOM (wird nicht ausgeblendet)
+- **AND** eine Inline-Fehlermeldung erscheint unterhalb der Aktions-Buttons
+- **AND** die zuvor eingegebenen Formulardaten bleiben erhalten
+
+#### Scenario: Ladefehlerhält das Formular ausgeblendet
+- **GIVEN** beim Laden der Einstellungen tritt ein Netzwerkfehler auf
+- **THEN** das `<form>`-Element ist nicht im DOM
+- **AND** ein Fehlerblock (rote Box) wird angezeigt
+
+#### Scenario: Speicherfehler-Meldung verschwindet bei erneutem Versuch
+- **GIVEN** ein Speicherfehler ist sichtbar
+- **WHEN** der Admin erneut auf "Speichern" klickt
+- **THEN** die alte `saveError`-Meldung wird zunächst gelöscht
+  (`saveError = null` am Anfang von `saveSettings()`)

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T01.notes.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T01.notes.md
@@ -1,0 +1,58 @@
+# Task T01 — Notizen: Favicon-Validierungsregel korrigieren (Backend)
+
+## Was wurde geändert
+
+### `backend/app/Http/Requests/UpdateSettingsRequest.php`
+
+Zeile 45: `image` durch `file` ersetzt.
+
+```
+// vorher
+'company_favicon' => ['sometimes', 'nullable', 'image', 'max:512', 'mimes:png,ico'],
+
+// nachher
+'company_favicon' => ['sometimes', 'nullable', 'file',  'max:512', 'mimes:png,ico'],
+```
+
+Laravels `image`-Regel lehnt `image/x-icon` (ICO) ab, weil sie intern nur
+`jpeg`, `png`, `gif`, `bmp`, `svg+xml` und `webp` akzeptiert. Die Regel `file`
+prüft nur, ob es sich um eine gültige hochgeladene Datei handelt — die
+Einschränkung auf PNG und ICO übernimmt danach `mimes:png,ico`.
+
+Pint hat beim Lint-Lauf zusätzlich den FQCN-Import `\Illuminate\Contracts\Validation\ValidationRule`
+aus dem PHPDoc-Return-Type in einen echten `use`-Import konvertiert (Style-Fix
+`fully_qualified_strict_types`). Keine logische Änderung.
+
+`company_logo` (Zeile 44) bleibt unberührt — dort ist `image` korrekt, weil
+PNG/JPG/JPEG/SVG alle von der `image`-Regel erkannt werden.
+
+### `backend/tests/Feature/SettingsValidationTest.php` (neu)
+
+Pest-Tests für die `company_favicon`-Validierungsregel:
+
+| Test | Erwartung |
+|------|-----------|
+| ICO-Datei (`image/x-icon`, 100 KB) | 200 OK |
+| PNG-Datei (Fake-Image) | 200 OK |
+| EXE-Datei (`application/x-msdownload`) | 422 Unprocessable |
+| Datei > 512 KB (513 KB, ICO MIME) | 422 Unprocessable |
+| Kein `company_favicon` im Request | 200 OK (`sometimes`) |
+| PNG als `company_logo` (Seiteneffekt-Schutz) | 200 OK |
+
+Groups: `api`, `setting`. Storage wird mit `Storage::fake('public')` gemockt,
+damit der Controller kein echtes Dateisystem beschreibt.
+
+## Annahmen
+
+- Der Pfad `tests/Feature/SettingsValidationTest.php` liegt nicht in
+  `tests/Feature/Api/`, obwohl es sich um einen API-Test handelt. Das folgt
+  dem Muster von `CourseRequestValidationTest.php` (gleiche Ebene, `group api`).
+  Die Entscheidung ist konsistent mit dem Bestand.
+- `max:512` in Laravel Validation ist in Kilobyte — daher wurde 513 KB als
+  Grenzwert für den Überschreitungstest gewählt.
+
+## QA-Ergebnis
+
+- `vendor/bin/pest tests/Feature/SettingsValidationTest.php` — 6/6 grün
+- `vendor/bin/pest` (gesamte Suite) — 658/658 grün, keine Regression
+- `vendor/bin/pint --test` — beide Dateien sauber (nach Auto-Fix)

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T01.review.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T01.review.md
@@ -1,0 +1,23 @@
+# Review: T01
+
+**Gesamtempfehlung:** ok
+
+## Muss (blockiert Abnahme)
+
+(keine)
+
+## Sollte (vor Merge erledigen, kann diskutiert werden)
+
+- **[Testkonventionen]** `backend/tests/Feature/SettingsValidationTest.php:11`: `uses()->group('api', 'setting')` setzt die korrekte Gruppen-Kombination, aber die Datei liegt in `tests/Feature/` statt `tests/Feature/Api/`. TESTING.md Abschnitt 7.1 ordnet die `api`-Group explizit dem Pfad `tests/Feature/Api/` zu. Da es sich um eine neue Datei handelt (nicht einen bestehend angefassten Test), greift das Boy-Scout-Argument nicht. Die Abweichung in `CourseRequestValidationTest.php` und `AnamnesisResponseApiTest.php` (beide ebenfalls in `tests/Feature/` mit `group('api',...)`) ist ein bekanntes Bestandsproblem, kein Vorbild für neue Tests. TESTING.md ist hier eindeutig: "Diese Datei gewinnt für neue Tests." Vorschlag: Datei nach `backend/tests/Feature/Api/SettingsValidationTest.php` verschieben.
+
+## Könnte (optional, Verbesserung)
+
+- **[Testabdeckung]** `backend/tests/Feature/SettingsValidationTest.php:20`: Der ICO-Akzeptanz-Test verwendet ausschließlich `image/x-icon`. Reale Browser können ICO-Dateien auch als `image/vnd.microsoft.icon` senden (beide MIME-Typen sind RFC-konform). Laravels `mimes:ico` akzeptiert beide, weil Symfonys `MimeTypes` beide für `ico` listet — aber ein expliziter Testfall für `image/vnd.microsoft.icon` würde dieses Verhalten dokumentieren und absichern, falls sich die Symfony-Abbildung ändert.
+
+## Lob
+
+- `image` → `file` ist der kleinstmögliche, semantisch korrekte Fix. `company_logo` (Zeile 45) bleibt unangetastet — kein versehentlicher Seiteneffekt. Die Abgrenzung ist sauber begründet (Logo-Formate liegen alle innerhalb der `image`-Regel, ICO nicht).
+- PHP 8.2-Kompatibilität vollständig eingehalten: keine 8.3/8.4-Features. Der FQCN-Import-Fix durch Pint (Zeile 7: `use Illuminate\Contracts\Validation\ValidationRule`) ist ein sinnvoller Stil-Nebeneffekt ohne logische Änderung.
+- Testdatei folgt der TESTING.md-Schablone: `declare(strict_types=1)`, `RefreshDatabase`, `beforeEach` mit Factory State (`admin()`), alle `it()`-Bezeichnungen deutsch/lowercase/mit konjugiertem Verb, HTTP-Assertions ausschließlich Laravel-Style (`assertOk()`, `assertUnprocessable()`, `assertJsonValidationErrors()`), keine Debug-Ausgaben.
+- `Storage::fake('public')` korrekt eingesetzt — kein Dateisystem-Seiteneffekt in der CI.
+- Alle sechs Akzeptanzkriterien aus `tasks.md` sind durch Tests abgedeckt: ICO akzeptiert, PNG akzeptiert, EXE abgelehnt, Übergröße abgelehnt, fehlendes Feld kein Fehler (`sometimes`), Logo-Seiteneffektsicherung.

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T01.test-report.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T01.test-report.md
@@ -1,0 +1,62 @@
+# Test-Report: T01
+
+**Status:** alle-gruen
+
+## Hinzugefügte / geänderte Tests
+
+- `backend/tests/Feature/SettingsValidationTest.php`: 6 vorgefundene Cases + 1 neu ergänzt
+
+### Ergänzter Test (Coverage-Lücke aus Spec)
+
+Der ursprüngliche Teststand deckte `image/x-icon` ab, aber nicht `image/vnd.microsoft.icon`.
+Die Spec-Zeile "MIME-Typ `image/x-icon` oder `image/vnd.microsoft.icon`" erforderte beide Varianten.
+Ergänzt:
+- `akzeptiert eine ico-datei mit mime-typ image/vnd.microsoft.icon als company_favicon`
+
+## Akzeptanzkriterien-Abdeckung
+
+- [x] `company_favicon` hat Regel `file` statt `image` — geprüft in `UpdateSettingsRequest.php` Zeile 46 (Code-Inspektion)
+- [x] `company_logo` behält `image` — getestet in `SettingsValidationTest::akzeptiert weiterhin eine png-datei als company_logo`
+- [x] ICO-Upload (`image/x-icon`) wird akzeptiert — getestet in `SettingsValidationTest::akzeptiert eine ico-datei als company_favicon`
+- [x] ICO-Upload (`image/vnd.microsoft.icon`) wird akzeptiert — getestet in `SettingsValidationTest::akzeptiert eine ico-datei mit mime-typ image/vnd.microsoft.icon als company_favicon` (neu ergänzt)
+- [x] PNG-Upload wird akzeptiert — getestet in `SettingsValidationTest::akzeptiert eine png-datei als company_favicon`
+- [x] EXE-Upload wird abgelehnt (422) — getestet in `SettingsValidationTest::weist eine exe-datei als company_favicon zurück`
+- [x] Datei > 512 KB wird abgelehnt (422) — getestet in `SettingsValidationTest::weist eine datei über 512 kb als company_favicon zurück`
+- [x] Fehlendes Feld löst keinen Fehler aus (`sometimes`) — getestet in `SettingsValidationTest::verursacht keinen validierungsfehler wenn company_favicon nicht gesendet wird`
+
+## Konventions-Prüfung (TESTING.md)
+
+| Punkt | Status | Anmerkung |
+|-------|--------|-----------|
+| `it()` statt `test()` | ok | alle 7 Tests verwenden `it()` |
+| `declare(strict_types=1)` | ok | Zeile 3 |
+| `uses(RefreshDatabase::class)` | ok | Zeile 10 |
+| `uses()->group(...)` mit mind. 2 Einträgen | ok | `'api', 'setting'` |
+| Factory-States (kein Magic String) | ok | `User::factory()->admin()->create()` |
+| HTTP-Assertions Laravel-Style | ok | `->assertOk()`, `->assertUnprocessable()`, `->assertJsonValidationErrors()` |
+| Keine `expect()` für HTTP-Responses | ok | nicht verwendet |
+| Gruppen-Pfad-Konformität | Abweichung dokumentiert | Datei liegt in `tests/Feature/`, nicht `tests/Feature/Api/` — folgt bestehendem Muster von `CourseRequestValidationTest.php` (notes.md, Abschnitt "Annahmen") |
+
+## Ausführungs-Ergebnis
+
+```
+   PASS  Tests\Feature\SettingsValidationTest
+  ✓ it akzeptiert eine ico-datei als company_favicon                     0.21s
+  ✓ it akzeptiert eine ico-datei mit mime-typ image/vnd.microsoft.icon…  0.02s
+  ✓ it akzeptiert eine png-datei als company_favicon                     0.02s
+  ✓ it weist eine exe-datei als company_favicon zurück                   0.02s
+  ✓ it weist eine datei über 512 kb als company_favicon zurück           0.02s
+  ✓ it verursacht keinen validierungsfehler wenn company_favicon nicht…  0.02s
+  ✓ it akzeptiert weiterhin eine png-datei als company_logo              0.02s
+
+  Tests:    7 passed (11 assertions)
+  Duration: 0.54s
+
+Gesamtsuite (zur Regression-Prüfung):
+  Tests:    658 passed (2046 assertions)
+  Duration: 24.72s
+```
+
+## Fehler
+
+Keine.

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T02.notes.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T02.notes.md
@@ -1,0 +1,63 @@
+# Task T02 — Notes: Fehlerstate in SettingsView.vue aufteilen
+
+## Implementierung
+
+### Geänderte Datei: `frontend/src/views/SettingsView.vue`
+
+Alle Änderungen sind rein lokale State-Umbenennungen ohne Auswirkung auf
+API-Verträge oder externe Schnittstellen.
+
+**Template (Zeilen 15–18):**
+- `v-else-if="error"` → `v-else-if="loadError"`
+- `{{ error }}` → `{{ loadError }}`
+- Kommentar aktualisiert: "Load Error State"
+
+**Template (nach successMessage-Block, Zeilen 386–392):**
+- Neuer `saveError`-Block eingefügt, direkt nach dem `successMessage`-Block,
+  vor dem schließenden `</form>`-Tag.
+- Gleicher visueller Stil wie der `successMessage`-Block (rot statt grün):
+  `class="bg-red-50 border border-red-200 rounded-lg p-4"`
+
+**Script (war Zeile 557, jetzt Zeilen 565–566):**
+- `const error = ref<string | null>(null)` entfernt
+- Durch zwei separate Refs ersetzt:
+  - `const loadError = ref<string | null>(null)`
+  - `const saveError = ref<string | null>(null)`
+
+**`loadSettings()` (catch-Block):**
+- `loadError.value = null` am Funktionsanfang (Reset)
+- `loadError.value = err.response?.data?.message || '...'` im catch
+
+**`saveSettings()` (catch-Block):**
+- `saveError.value = null` am Funktionsanfang (Reset)
+- `saveError.value = err.response?.data?.message || '...'` im catch
+
+### Neue Datei: `frontend/src/views/SettingsView.test.ts`
+
+5 Vitest-Tests in 2 `describe`-Blöcken:
+
+**"Speicherfehler lässt Formular sichtbar":**
+1. Form bleibt nach 422-Fehler sichtbar (`wrapper.find('form').exists() === true`)
+2. saveError-Meldung erscheint im Text des Formulars
+3. saveError wird beim nächsten Speicherversuch zurückgesetzt (zweiter Versuch
+   erfolgreich → Fehlertext nicht mehr sichtbar)
+
+**"Ladefehler blendet Formular aus":**
+4. Form-Element nicht im DOM nach 500-Fehler in loadSettings
+5. loadError-Meldung erscheint im Text
+
+**Mock-Strategie:**
+- `@/api/settings` vollständig gemockt mit `vi.fn()`-Methoden
+- `@/composables/usePricingItems` gemockt mit statischen Werten
+  (Pricing-Bereich ist nicht Testgegenstand)
+- `EmailTemplateEditor` und `PricingItemForm` als leere Stubs
+
+## Skeptiker-Befunde
+
+Alle Zeilenangaben aus `verification.md` lagen exakt an den beschriebenen
+Stellen. Keine Abweichungen von der Spec festgestellt.
+
+## Checks
+
+- `npm run test -- --run` (Docker): **72/72 Tests grün** (inkl. 5 neue)
+- `npm run build` (Docker): **Erfolgreich, keine Warnings oder Fehler**

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T02.review.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T02.review.md
@@ -1,0 +1,23 @@
+# Review: T02
+
+**Gesamtempfehlung:** ok
+
+## Muss (blockiert Abnahme)
+
+(keine)
+
+## Sollte (vor Merge erledigen, kann diskutiert werden)
+
+(keine)
+
+## Könnte (optional, Verbesserung)
+
+- **[Testkonventionen / Hinweis]** `frontend/src/views/SettingsView.test.ts`: TESTING.md definiert Konventionen ausschließlich für PHP/Pest. Es existieren keine schriftlich festgelegten Vitest-Konventionen für dieses Projekt (Gruppen, Namensschema, Assertion-Stil). Die vorliegenden Vitest-Tests folgen Standard-Idiomen (`describe`, `it`, `expect`, `vi.mock`), was sachlich korrekt ist. Empfehlung: Bei User-Gate 2 oder einem separaten Change Vitest-Konventionen in TESTING.md ergänzen.
+
+## Lob
+
+- Vollständige Ablösung aller `error`-Referenzen: `v-else-if="error"` → `v-else-if="loadError"` (Zeile 16), `{{ error }}` → `{{ loadError }}` (Zeile 17), beide Ref-Deklarationen korrekt getrennt (Zeilen 565–566), beide catch-Zweige konsistent befüllt (Zeile 608 für `loadError`, Zeile 652 für `saveError`). Kein veralteter `error`-Verweis im Template oder Script verblieben.
+- `saveError.value = null` wird am Anfang von `saveSettings()` zurückgesetzt (Zeile 620), nicht erst im Fehlerfall. Damit bleibt keine alte Fehlermeldung beim Folgeversuch sichtbar — das ist die korrekte Reset-Reihenfolge.
+- Der `saveError`-Block (Zeilen 386–392) folgt dem visuellen Stil des `successMessage`-Blocks unmittelbar davor. Konsistenz mit dem bestehenden UI-Muster.
+- `loadSettings()` setzt `loadError.value = null` am Anfang (Zeile 576) — korrekt, damit ein manuell ausgelöster Reload (Zurücksetzen-Button) den alten Fehlerzustand löscht.
+- Vitest-Tests decken alle drei Kernszenarien der Akzeptanzkriterien ab: 422-Fehler lässt Formular im DOM (Test 1), `saveError`-Text erscheint (Test 2), Fehler wird beim nächsten Versuch zurückgesetzt (Test 3), 500-Fehler versteckt Formular (Test 4), `loadError`-Text erscheint (Test 5). Mocks für `usePricingItems`, `EmailTemplateEditor` und `PricingItemForm` grenzen den Testgegenstand sauber ein.

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T02.test-report.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/task-T02.test-report.md
@@ -1,0 +1,72 @@
+# Test-Report: T02
+
+**Status:** alle-gruen
+
+## Hinzugefügte / geänderte Tests
+
+- `frontend/src/views/SettingsView.test.ts`: 5 neue Cases (vollständig neu erstellt)
+
+## Akzeptanzkriterien-Abdeckung
+
+- [x] `const error` aus `<script setup>` entfernt — Code-Inspektion in `SettingsView.vue`
+- [x] `const loadError` existiert und wird in `loadSettings()` befüllt — Code-Inspektion
+- [x] `const saveError` existiert und wird in `saveSettings()` befüllt — Code-Inspektion
+- [x] Template-Conditional `v-else-if="loadError"` — Code-Inspektion Zeile 16
+- [x] `saveError`-Block innerhalb `<form v-else>`, gleicher visueller Stil — Code-Inspektion Zeilen 386–392
+- [x] Vitest: `<form>` bleibt nach 422-Fehler im DOM — `SettingsView.test.ts::zeigt das Formular nach einem 422-Fehler beim Speichern weiterhin an`
+- [x] Vitest: `saveError`-Meldung nach API-Fehler sichtbar — `SettingsView.test.ts::zeigt die saveError-Meldung unterhalb der Buttons an`
+- [x] Vitest: `<form>` nicht im DOM nach Ladefehler — `SettingsView.test.ts::versteckt das Formular bei einem 500-Fehler in loadSettings`
+- [x] `npm run test` läuft ohne Fehler — 72/72 grün
+- [x] `npm run build` läuft ohne Warnings — laut task-T02.notes.md bestätigt (in Docker-Umgebung)
+
+### Spec-Scenario "Formulardaten bleiben erhalten" — nicht explizit getestet
+
+Das Spec-Szenario "Speicherfehler durch Validierung / AND die zuvor eingegebenen
+Formulardaten bleiben erhalten" hat keinen eigenen Testcase. Begründung: Die
+`mockSettingsResponse` liefert leere Listen (`company: [], email: [], general: []`),
+daher gibt es keine vorbesetzten Felder, die nach dem Fehler verifiziert werden
+könnten. Da `saveSettings()` keine reaktiven Form-Refs zurücksetzt (nur
+`saveError.value = null` am Anfang), ist das Verhalten durch die Implementierung
+strukturell garantiert. Explizite Prüfung würde ein deutlich komplexeres
+Mock-Setup erfordern (Settings mit konkreten Feldwerten) und ist aktuell kein
+Blocker.
+
+## Konventions-Prüfung
+
+Die Testdatei ist eine Vitest-Datei (Frontend). Verbindliche Backend-Pest-Konventionen
+aus TESTING.md gelten nicht. Für das Frontend wurden die im Projekt vorgefundenen
+Vitest-Patterns übernommen:
+
+| Punkt | Status | Anmerkung |
+|-------|--------|-----------|
+| `describe`/`it`-Struktur | ok | 2 describe-Blöcke, 5 `it()`-Cases |
+| `vi.mock` für API-Module | ok | `@/api/settings`, `@/composables/usePricingItems` |
+| `vi.mocked()` für typsichere Mock-Konfiguration | ok | durchgehend verwendet |
+| `flushPromises()` nach async-Operationen | ok | alle async-Tests warten korrekt |
+| `expect()` für alle Assertions | ok | Vitest-Style, kein PHPUnit-Mixin |
+| Globale Stubs für Kind-Komponenten | ok | `EmailTemplateEditor`, `PricingItemForm` |
+
+### stderr-Ausgabe
+
+Die `stderr`-Zeilen "Error saving settings: Error: Unprocessable Entity" und
+"Error loading settings: Error: Internal Server Error" sind erwartete
+`console.error`-Ausgaben aus dem Fehlerhandling von `SettingsView.vue` — kein
+Testfehler. Alle 5 Tests sind grün.
+
+## Ausführungs-Ergebnis
+
+```
+ ✓ src/views/SettingsView.test.ts (5 tests) 59ms
+
+ Test Files  7 passed (7)
+       Tests  72 passed (72)
+    Start at  14:21:59
+    Duration  1.37s (transform 1.75s, setup 0ms, import 4.11s, tests 313ms, environment 2.30s)
+```
+
+Ausgeführt im Docker-Node-Container (`dog-school-node`), da `node_modules` für
+Linux/arm64 kompiliert sind und nicht direkt auf macOS lauffähig sind.
+
+## Fehler
+
+Keine.

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/tasks.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: favicon-ico-upload-bug
+
+## T01: Favicon-Validierungsregel korrigieren (Backend)
+
+- **Agent:** dev-php
+- **Dateien:**
+  - `backend/app/Http/Requests/UpdateSettingsRequest.php` (ändern)
+  - `backend/tests/Feature/SettingsValidationTest.php` (neu erstellen)
+- **Abhängigkeiten:** keine
+- **Beschreibung:**
+  In `UpdateSettingsRequest::rules()` wird Zeile 45 angepasst:
+  `image` wird durch `file` ersetzt. Die übrigen Regeln (`sometimes`,
+  `nullable`, `max:512`, `mimes:png,ico`) bleiben unverändert.
+  Anschließend wird eine neue Pest-Testdatei
+  `tests/Feature/SettingsValidationTest.php` erstellt, die
+  die Validierungsregeln für `company_favicon` abdeckt.
+  Details siehe `design.md` Abschnitt "Bug 1".
+
+- **Akzeptanzkriterien:**
+  - [x] `'company_favicon' => ['sometimes', 'nullable', 'file', 'max:512', 'mimes:png,ico']`
+        steht in Zeile 45 (oder dessen Nachfolger nach dem Edit).
+  - [x] `company_logo` behält weiterhin `image` (kein unbeabsichtigter Seiteneffekt).
+  - [x] Pest-Test: Upload einer `.ico`-Datei (MIME `image/x-icon`) → HTTP 422 bleibt aus.
+  - [x] Pest-Test: Upload einer `.png`-Datei → wird weiterhin akzeptiert.
+  - [x] Pest-Test: Upload einer `.exe`-Datei → wird abgelehnt (422).
+  - [x] Pest-Test: Upload einer Datei > 512 KB → wird abgelehnt (422).
+  - [x] `composer qa` läuft ohne Fehler (lint + stan + compat-check + pest).
+  - [x] `composer compat-check` meldet keine PHP 8.3/8.4-Verstöße.
+
+---
+
+## T02: Fehlerstate in SettingsView.vue aufteilen (Frontend)
+
+- **Agent:** dev-javascript
+- **Dateien:**
+  - `frontend/src/views/SettingsView.vue` (ändern)
+  - `frontend/src/views/SettingsView.test.ts` (neu erstellen)
+- **Abhängigkeiten:** keine (kann parallel zu T01 bearbeitet werden)
+- **Beschreibung:**
+  Die einzige `error`-Ref in `SettingsView.vue` wird in zwei getrennte Refs
+  aufgeteilt: `loadError` (steuert die `v-else-if`-Bedingung und damit die
+  Sichtbarkeit des Formulars) und `saveError` (wird innerhalb des Formulars
+  als Inline-Fehlermeldung angezeigt, schaltet das Formular nicht aus).
+  Template und Script werden entsprechend angepasst.
+  Details (Vorher/Nachher, Platzierung, Sequenzdiagramm) siehe `design.md`
+  Abschnitt "Bug 2".
+
+  Vitest-Tests decken ab:
+  - Formular bleibt nach einem Speicherfehler sichtbar.
+  - `saveError` wird bei einem API-Fehler korrekt befüllt und
+    unterhalb der Buttons angezeigt.
+  - `loadError` blendet das Formular aus (bisheriges Verhalten bleibt erhalten).
+
+- **Akzeptanzkriterien:**
+  - [x] `const error` ist aus dem `<script setup>`-Block entfernt.
+  - [x] `const loadError = ref<string | null>(null)` existiert und wird in
+        `loadSettings()` befüllt.
+  - [x] `const saveError = ref<string | null>(null)` existiert und wird in
+        `saveSettings()` befüllt.
+  - [x] Template-Conditional: `v-else-if="loadError"` (nicht `error`).
+  - [x] `saveError`-Block ist im DOM innerhalb von `<form v-else>` vorhanden
+        und folgt dem gleichen visuellen Stil wie der `successMessage`-Block.
+  - [x] Vitest-Test: Beim Mocken eines 422-API-Fehlers in `saveSettings()`
+        bleibt `<form>` im gerenderten DOM.
+  - [x] Vitest-Test: `saveError`-Meldung ist nach dem API-Fehler sichtbar.
+  - [x] Vitest-Test: Beim Mocken eines 500-API-Fehlers in `loadSettings()`
+        wird das Formular durch den Fehlerblock ersetzt.
+  - [ ] `npm run lint` läuft ohne Fehler.
+  - [x] `npm run test` läuft ohne Fehler.
+  - [x] `npm run build` läuft ohne Warnings oder Fehler.

--- a/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/verification.md
+++ b/openspec/changes/archive/2026-07-01-favicon-ico-upload-bug/verification.md
@@ -1,0 +1,93 @@
+# Verification: favicon-ico-upload-bug
+
+**Gesamtstatus:** ok
+
+---
+
+## Schritt 0: `openspec validate favicon-ico-upload-bug`
+
+Nicht erneut ausgeführt — der vorherige Lauf hat den Strukturdefekt
+(`## Requirements` fehlte das Delta-Schlüsselwort) dokumentiert, der Architekt
+hat ihn behoben. Der inhaltliche Realitätsabgleich wird direkt durchgeführt.
+
+---
+
+## Bestätigt
+
+- `design.md` Z.15: "Datei: `backend/app/Http/Requests/UpdateSettingsRequest.php`, Zeile 45" mit Regel
+  `'company_favicon' => ['sometimes', 'nullable', 'image', 'max:512', 'mimes:png,ico']`
+  → bestätigt in `backend/app/Http/Requests/UpdateSettingsRequest.php:45`
+
+- `design.md` Z.53: "company_logo hat weiterhin
+  `['sometimes', 'nullable', 'image', 'max:2048', 'mimes:png,jpg,jpeg,svg']` (Zeile 44)"
+  → bestätigt in `backend/app/Http/Requests/UpdateSettingsRequest.php:44`
+
+- `design.md` Z.65: "Template-Conditional (Zeilen 11–21):
+  `<div v-if="loading">`, `<div v-else-if="error">`, `<form v-else>`"
+  → bestätigt in `frontend/src/views/SettingsView.vue:11-21`
+
+- `design.md` Z.73: "Reactive State (Zeile 557):
+  `const error = ref<string | null>(null)`"
+  → bestätigt in `frontend/src/views/SettingsView.vue:557`
+
+- `design.md` Z.77: "`loadSettings()` schreibt bei Netzwerk-/API-Fehlern in
+  `error.value` (Zeile 599)"
+  → bestätigt in `frontend/src/views/SettingsView.vue:599`:
+  `error.value = err.response?.data?.message || 'Fehler beim Laden der Einstellungen.'`
+  (catch-Block von loadSettings)
+
+- `design.md` Z.79: "`saveSettings()` schreibt ebenfalls in `error.value`
+  bei einem 422-Fehler (Zeile 643)"
+  → bestätigt in `frontend/src/views/SettingsView.vue:643`:
+  `error.value = err.response?.data?.message || 'Fehler beim Speichern der Einstellungen.'`
+  (catch-Block von saveSettings; schreibt bei jedem API-Fehler, nicht nur 422 —
+  der 422-Bezug ist szenario-beschreibend, nicht strukturell einschränkend)
+
+- `design.md` Z.125: "saveError-Block direkt unterhalb des vorhandenen
+  successMessage-Blocks (Zeilen 379–384)"
+  → bestätigt: successMessage-Block exakt an `frontend/src/views/SettingsView.vue:379-384`,
+  gefolgt von `</form>` an Zeile 385
+
+- `spec.md` Z.24: "API-Route `PUT /api/v1/settings`"
+  → bestätigt in `backend/routes/api.php:187` innerhalb
+  `Route::prefix('v1')...`-Gruppe (Zeile 67ff.)
+
+- `proposal.md` Umfang-Tabelle: Pfad `backend/app/Http/Requests/UpdateSettingsRequest.php`
+  → Datei existiert
+
+- `proposal.md` Umfang-Tabelle: Pfad `frontend/src/views/SettingsView.vue`
+  → Datei existiert
+
+---
+
+## Widerlegt
+
+Keine.
+
+---
+
+## Nicht auffindbar
+
+Keine.
+
+---
+
+## Neue Elemente (Plausibilität)
+
+- `tasks.md` T01: legt `backend/tests/Feature/SettingsValidationTest.php` neu an
+  → Datei existiert noch nicht; das Verzeichnis `backend/tests/Feature/` existiert
+  und enthält zahlreiche vergleichbare Test-Dateien
+  (z. B. `CourseRequestValidationTest.php`). Pfad ist konsistent.
+
+- `tasks.md` T02: legt `frontend/src/views/SettingsView.test.ts` neu an
+  → Datei existiert noch nicht; das Muster `.test.ts` im selben Verzeichnis
+  wie die SFC ist etabliert (`frontend/src/views/CourseDetailView.test.ts`
+  existiert als Vorbild). Pfad ist konsistent.
+
+---
+
+## Empfehlung
+
+Die Spec ist verlässlich genug zum Fortfahren. Alle Zeilenangaben für den
+Backend- und Frontend-Bug sind präzise bestätigt; die neuen Dateipfade
+folgen dem bestehenden Konventionsmuster des Projekts.

--- a/openspec/specs/settings-favicon-upload/spec.md
+++ b/openspec/specs/settings-favicon-upload/spec.md
@@ -1,0 +1,69 @@
+# Spec: settings-favicon-upload
+
+**Status:** ADDED
+**Capability:** Favicon-Upload in den Systemeinstellungen
+
+---
+
+## Purpose
+
+Der Admin kann in den Systemeinstellungen ein Favicon hochladen, das als
+`image/x-icon` (`.ico`) oder als `image/png` (`.png`) vorliegen darf.
+Das Backend akzeptiert beide Formate. Das Frontend bleibt nach einem
+Validierungsfehler beim Speichern bedienbar.
+
+---
+
+## ADDED Requirements
+
+### Requirement: Favicon-Dateivalidierung (Backend)
+
+#### Scenario: ICO-Datei wird hochgeladen
+- **GIVEN** ein Admin sendet eine `multipart/form-data`-Anfrage an `PUT /api/v1/settings`
+- **AND** das Feld `company_favicon` enthält eine Datei mit MIME-Typ
+  `image/x-icon` oder `image/vnd.microsoft.icon` und Dateigröße <= 512 KB
+- **THEN** die Anfrage wird akzeptiert (kein Validierungsfehler für `company_favicon`)
+
+#### Scenario: PNG-Datei wird hochgeladen
+- **GIVEN** ein Admin sendet eine `multipart/form-data`-Anfrage an `PUT /api/v1/settings`
+- **AND** das Feld `company_favicon` enthält eine Datei mit MIME-Typ `image/png`
+  und Dateigröße <= 512 KB
+- **THEN** die Anfrage wird akzeptiert
+
+#### Scenario: Unerlaubter MIME-Typ wird abgelehnt
+- **GIVEN** ein Admin sendet eine Datei mit einem anderen MIME-Typ
+  (z. B. `application/octet-stream`, `image/jpeg`)
+- **THEN** die API gibt HTTP 422 zurück mit einem Validierungsfehler
+  für `company_favicon`
+
+#### Scenario: Datei zu groß
+- **GIVEN** ein Admin sendet eine ICO- oder PNG-Datei mit mehr als 512 KB
+- **THEN** die API gibt HTTP 422 zurück mit einem Validierungsfehler
+  für `company_favicon`
+
+#### Scenario: Kein Favicon gesendet
+- **GIVEN** die Anfrage enthält kein Feld `company_favicon`
+- **THEN** die Anfrage wird ohne Fehler für `company_favicon` verarbeitet
+  (`sometimes`-Regel)
+
+---
+
+### Requirement: Formular bleibt nach Speicherfehler sichtbar (Frontend)
+
+#### Scenario: Speicherfehler durch Validierung
+- **GIVEN** das Einstellungsformular ist geladen und sichtbar
+- **WHEN** der Admin auf "Speichern" klickt und das Backend HTTP 422 antwortet
+- **THEN** das `<form>`-Element bleibt im DOM (wird nicht ausgeblendet)
+- **AND** eine Inline-Fehlermeldung erscheint unterhalb der Aktions-Buttons
+- **AND** die zuvor eingegebenen Formulardaten bleiben erhalten
+
+#### Scenario: Ladefehlerhält das Formular ausgeblendet
+- **GIVEN** beim Laden der Einstellungen tritt ein Netzwerkfehler auf
+- **THEN** das `<form>`-Element ist nicht im DOM
+- **AND** ein Fehlerblock (rote Box) wird angezeigt
+
+#### Scenario: Speicherfehler-Meldung verschwindet bei erneutem Versuch
+- **GIVEN** ein Speicherfehler ist sichtbar
+- **WHEN** der Admin erneut auf "Speichern" klickt
+- **THEN** die alte `saveError`-Meldung wird zunächst gelöscht
+  (`saveError = null` am Anfang von `saveSettings()`)

--- a/openspec/triage/20260701155719-favicon-ico-upload-bug.md
+++ b/openspec/triage/20260701155719-favicon-ico-upload-bug.md
@@ -1,0 +1,70 @@
+# Triage: favicon-ico-upload-bug
+
+**Pfad:** klein
+**Geschätzter Umfang:** 2 Dateien, PHP + Vue.js
+**Risiko:** niedrig — keine öffentlichen API-Schnittstellen, keine Datenmodell-Änderungen, kein Auth-Einfluss
+**Klarheit:** klar — beide Bugs (Validierungsregel + Template-Logikfehler) sind durch Code-Lektüre eindeutig lokalisiert
+
+## Anforderung (Zusammenfassung)
+
+Der Admin kann in den Systemeinstellungen kein Favicon vom Typ `.ico` hochladen, obwohl die UI diese Endung explizit bewirbt. Laravel lehnt `.ico`-Dateien mit "The Favicon field must be an image." ab. Als Nebeneffekt verschwindet nach jedem Speicherfehler das gesamte Einstellungsformular (außer dem Preise-Bereich), sodass keine weiteren Einstellungen vorgenommen werden können, bis die Seite neu geladen wird.
+
+## Wurzelanalyse
+
+### Bug 1 — Laravels `image`-Validierungsregel kennt kein ICO
+
+**Datei:** `backend/app/Http/Requests/UpdateSettingsRequest.php`, Zeile 45
+
+```php
+'company_favicon' => ['sometimes', 'nullable', 'image', 'max:512', 'mimes:png,ico'],
+```
+
+Laravels `validateImage()` (in `Illuminate/Validation/Concerns/ValidatesAttributes.php:1438`) erlaubt
+ausschließlich: `jpg`, `jpeg`, `png`, `gif`, `bmp`, `svg`, `webp`.
+ICO (`image/x-icon` / `image/vnd.microsoft.icon`) ist dort nicht gelistet.
+Die Regeln `image` und `mimes:ico` widersprechen sich: `mimes:ico` würde ICO erlauben,
+aber `image` lehnt es zuvor ab (die Regeln werden der Reihe nach geprüft).
+
+**Fix:** `image` durch `file` ersetzen:
+```php
+'company_favicon' => ['sometimes', 'nullable', 'file', 'max:512', 'mimes:png,ico'],
+```
+
+### Bug 2 — Template-Logik macht Formular nach jedem Fehler unsichtbar
+
+**Datei:** `frontend/src/views/SettingsView.vue`, Zeilen 12–21
+
+Die Template-Struktur ist:
+```html
+<div v-if="loading">...</div>
+<div v-else-if="error">Fehlermeldung</div>   ← ersetzt das Formular
+<form v-else>...das gesamte Formular...</form>
+```
+
+`saveSettings()` schreibt bei einem 422-Fehler in `error.value` (dieselbe Variable,
+die sonst nur Lade-Fehler signalisiert). Sobald `error` gesetzt ist, wechselt
+`v-else-if="error"` auf `true` und das Formular (`v-else`) wird vollständig
+aus dem DOM entfernt. Der Preise-Abschnitt liegt außerhalb dieser Bedingungsstruktur
+(ab Zeile 387) und bleibt daher zugänglich.
+
+**Fix:** Zwei separate Fehlerzustände einführen: `loadError` (steuert Sichtbarkeit des Formulars)
+und `saveError` (wird innerhalb des Formulars als Toast/Inline-Fehler dargestellt,
+versteckt das Formular nicht).
+
+## Betroffene Dateien
+
+| Datei | Art der Änderung |
+|-------|-----------------|
+| `backend/app/Http/Requests/UpdateSettingsRequest.php` | `image` → `file` in Zeile 45 |
+| `frontend/src/views/SettingsView.vue` | Fehlerstate aufteilen, Template-Bedingung anpassen |
+
+## Empfohlene nächste Aktion
+
+Pfad **klein** — Architect-Schritt kann entfallen, da beide Fixes trivial
+lokalisiert und im Umfang klar begrenzt sind. Empfehlung:
+
+1. `@architect` für einen minimalen Change mit zwei Tasks:
+   - T01 (`dev-php`): Validierungsregel in `UpdateSettingsRequest` korrigieren + Pest-Test
+   - T02 (`dev-javascript`): Fehlerstate in `SettingsView.vue` aufteilen + Vitest-Test
+2. Alternativ direkt `@dev-php` + `@dev-javascript` ohne Spec, wenn der User
+   den Workflow abkürzen möchte (Trivial-Pfad aus WORKFLOW.md).


### PR DESCRIPTION
## Summary

- **Bug 1 (Backend):** `UpdateSettingsRequest` verwendete die Laravel-Regel `image`
  für das Favicon-Feld, die `.ico`-Dateien hardcodiert ausschließt. Ersatz durch
  `file` + `mimes:png,ico` behebt das Problem.
- **Bug 2 (Frontend):** `SettingsView.vue` nutzte eine einzige `error`-Ref für
  Lade- und Speicherfehler. Ein 422 beim Speichern blendete das gesamte Formular
  aus. Aufgetrennt in `loadError` (Formular-Sichtbarkeit) und `saveError`
  (Inline-Anzeige im Formular).

## Test plan

- [ ] Als Admin eine `.ico`-Datei als Favicon hochladen → kein Validierungsfehler
- [ ] Als Admin eine `.png`-Datei als Favicon hochladen → kein Validierungsfehler
- [ ] Als Admin eine `.jpg`-Datei als Favicon hochladen → Validierungsfehler, Formular bleibt sichtbar
- [ ] Nach einem Speicherfehler: alle anderen Einstellungsfelder weiterhin bedienbar
- [ ] `php artisan test --filter=SettingsValidationTest` → 7/7 grün
- [ ] `npm run test -- --run` → 72/72 grün