### PR TITLE
fix: Firmenlogo/Favicon verschwinden beim Speichern der Settings

### DIFF
--- a/frontend/src/api/settings.test.ts
+++ b/frontend/src/api/settings.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { settingsApi } from '@/api/settings'
+import apiClient from '@/api/client'
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+  },
+}))
+
+describe('settingsApi.updateSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { data: {} } })
+  })
+
+  it('sends the request via apiClient.post, not apiClient.put', async () => {
+    await settingsApi.updateSettings({ company_name: 'Test' })
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1)
+    expect(apiClient.put).not.toHaveBeenCalled()
+  })
+
+  it('posts to the /api/v1/settings endpoint with multipart headers', async () => {
+    await settingsApi.updateSettings({ company_name: 'Test' })
+
+    const [url, , config] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect(url).toBe('/api/v1/settings')
+    expect(config?.headers).toEqual({ 'Content-Type': 'multipart/form-data' })
+  })
+
+  it('appends a _method=PUT field to the FormData for method override', async () => {
+    await settingsApi.updateSettings({ company_name: 'Test' })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect(formData).toBeInstanceOf(FormData)
+    expect((formData as FormData).get('_method')).toBe('PUT')
+  })
+
+  it('carries text fields into the FormData unchanged', async () => {
+    await settingsApi.updateSettings({ company_name: 'Hundeschule Musterstadt' })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect((formData as FormData).get('company_name')).toBe('Hundeschule Musterstadt')
+  })
+
+  it('carries a File value into the FormData unchanged', async () => {
+    const logo = new File(['logo-bytes'], 'logo.png', { type: 'image/png' })
+
+    await settingsApi.updateSettings({ company_logo: logo })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    const uploaded = (formData as FormData).get('company_logo')
+    expect(uploaded).toBeInstanceOf(File)
+    expect((uploaded as File).name).toBe('logo.png')
+  })
+
+  it('skips null and undefined values', async () => {
+    await settingsApi.updateSettings({ company_name: 'Test', unset_field: null, missing_field: undefined })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect((formData as FormData).has('unset_field')).toBe(false)
+    expect((formData as FormData).has('missing_field')).toBe(false)
+  })
+
+  it('still sends only the _method field when called with an empty settings object', async () => {
+    await settingsApi.updateSettings({})
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect((formData as FormData).get('_method')).toBe('PUT')
+    expect(Array.from((formData as FormData).keys())).toEqual(['_method'])
+  })
+
+  it('carries multiple File values (logo and favicon) into the FormData at once', async () => {
+    const logo = new File(['logo-bytes'], 'logo.png', { type: 'image/png' })
+    const favicon = new File(['favicon-bytes'], 'favicon.ico', { type: 'image/vnd.microsoft.icon' })
+
+    await settingsApi.updateSettings({ company_logo: logo, company_favicon: favicon })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    const uploadedLogo = (formData as FormData).get('company_logo')
+    const uploadedFavicon = (formData as FormData).get('company_favicon')
+    expect(uploadedLogo).toBeInstanceOf(File)
+    expect((uploadedLogo as File).name).toBe('logo.png')
+    expect(uploadedFavicon).toBeInstanceOf(File)
+    expect((uploadedFavicon as File).name).toBe('favicon.ico')
+  })
+
+  it('coerces non-string primitive values (number, boolean) to strings in the FormData', async () => {
+    await settingsApi.updateSettings({ max_dogs: 5, is_active: true })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect((formData as FormData).get('max_dogs')).toBe('5')
+    expect((formData as FormData).get('is_active')).toBe('true')
+  })
+
+  it('resolves with the response data returned by apiClient.post', async () => {
+    const payload = { data: { general: [] }, message: 'Settings updated' }
+    vi.mocked(apiClient.post).mockResolvedValue({ data: payload })
+
+    const result = await settingsApi.updateSettings({ company_name: 'Test' })
+
+    expect(result).toEqual(payload)
+  })
+})

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -45,7 +45,19 @@ export const settingsApi = {
       }
     })
 
-    const response = await apiClient.put<SettingsResponse>('/api/v1/settings', formData, {
+    // set() (not append()) after the loop so a settings key named
+    // `_method` can never shadow the override via PHP's last-wins
+    // multipart field semantics.
+    formData.set('_method', 'PUT')
+
+    // Sent as POST with a Laravel method-override field (`_method=PUT`)
+    // instead of a real HTTP PUT. PHP only populates $_POST/$_FILES
+    // natively on a real POST request; parsing a multipart body on a
+    // real PUT is PHP-version-/server-dependent and drops uploaded
+    // files. Laravel's enableHttpMethodParameterOverride() rewrites the
+    // method from the `_method` field before routing, so the route
+    // stays `Route::put('/settings', ...)`.
+    const response = await apiClient.post<SettingsResponse>('/api/v1/settings', formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },

--- a/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/acceptance.md
+++ b/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/acceptance.md
@@ -1,0 +1,177 @@
+# Abnahme: fix-settings-upload-put-multipart
+
+**Status:** bereit-für-user-review
+
+---
+
+## 0. Strukturelle Validität
+
+```
+$ openspec validate fix-settings-upload-put-multipart --strict
+Change 'fix-settings-upload-put-multipart' is valid
+```
+
+Strukturell einwandfrei (Frontmatter, Pflichtfelder, Spec-Delta-Form). Deckt
+sich mit dem bereits vom Skeptiker in `verification.md` (Z.7-9) gemeldeten
+Ergebnis des einfachen `validate`-Laufs.
+
+---
+
+## 1. Vollständigkeit (`tasks.md`)
+
+T01 ist vollständig als erledigt markiert. Von 11 Akzeptanzkriterien sind
+10 mit `[x]` abgehakt, eines mit `[~]` (dokumentierte, begründete
+Abweichung: `npm run lint` existiert im Projekt nicht — kein `lint`-Script
+in `frontend/package.json`, keine ESLint-Config; bestätigt per eigenem
+`grep -i lint frontend/package.json` → kein Treffer). Das ist ein
+bestehender Projektzustand außerhalb des Scopes von T01, korrekt dokumentiert
+in `task-T01.notes.md` und `task-T01.test-report.md`, keine Nacharbeit
+erforderlich.
+
+---
+
+## 2. Spec-Konformität (Diff gegen `design.md`/`spec.md`)
+
+Aktueller Stand von `frontend/src/api/settings.ts` (per `Read`, Zeilen 35-66)
+und `git diff HEAD -- frontend/src/api/settings.ts` geprüft:
+
+- `apiClient.put(...)` → `apiClient.post(...)`: bestätigt (Zeile 60).
+- Endpunkt `/api/v1/settings` unverändert: bestätigt.
+- Header `Content-Type: multipart/form-data` unverändert: bestätigt.
+- `FormData`-Feld `_method=PUT`: vorhanden, aber **anders platziert als im
+  ursprünglichen `design.md`-Codeblock** (Z.140: `formData.append('_method',
+  'PUT')` **vor** der `forEach`-Schleife). Der tatsächliche Code setzt
+  stattdessen `formData.set('_method', 'PUT')` **nach** der Schleife
+  (Zeilen 48-51), exakt wie vom Reviewer in `task-T01.review.md`
+  ("Sollte"-Befund 2, Z.27-46) vorgeschlagen.
+
+  Das ist mit `specs/settings-file-upload-transport/spec.md` konform: die
+  Requirement-Formulierung (Z.25-34) und alle vier Szenarien (Z.36-68)
+  verlangen lediglich, dass der `FormData`-Body ein Feld `_method` mit Wert
+  `PUT` enthält und der Request per POST an `/api/v1/settings` geht — die
+  interne Reihenfolge/Methode (`.append()` vs. `.set()`, vor vs. nach der
+  Schleife) ist nicht Teil der Spec-Formulierung. Die Änderung ist also
+  spec-konform und zusätzlich robuster (verhindert, dass ein hypothetischer
+  `settings`-Schlüssel `_method` den Override per PHP-Multipart-"last-wins"
+  überschreiben könnte).
+
+  **Randnotiz (nicht blockierend):** `tasks.md` Akzeptanzkriterium 1 nennt
+  wörtlich `formData.append('_method', 'PUT')` — das ist nach dieser
+  nachträglichen Änderung textlich leicht veraltet (jetzt `.set()`, andere
+  Position), der fachliche Kern des Kriteriums (Feld wird vor dem Absenden
+  gesetzt) bleibt aber erfüllt. Empfehlung: `tasks.md` bei Gelegenheit
+  redaktionell nachziehen, kein Merge-Blocker.
+
+- Kein Backend-Code angefasst: bestätigt, `git status --short` zeigt nur
+  `frontend/src/api/settings.ts` (modifiziert) und `frontend/src/api/settings.test.ts`
+  (neu) als inhaltliche Änderungen dieses Changes.
+- Route `backend/routes/api.php:195` unangetastet: vom Reviewer bereits
+  bestätigt (`task-T01.review.md`, "Lob"-Abschnitt), stichprobenartig
+  gegengeprüft — keine Backend-Datei im Diff.
+
+**Prozess-Hinweis:** Diese konkrete Korrektur (`.set()` nach der Schleife)
+wurde nicht über den regulären `dev-javascript`-Task-Zyklus (Schritt 10 der
+`WORKFLOW.md`) eingespielt, sondern manuell vom Orchestrator nachgezogen,
+nachdem der Reviewer sie als "Sollte"-Befund vorgeschlagen hatte. Dadurch
+wurde der finale Diff nicht noch einmal formal vom Reviewer gegengelesen.
+Ich habe das als Architekt eigenständig nachgeprüft (Diff gelesen, Tests
+selbst ausgeführt, s. Abschnitt 4) und keine Abweichung von Spec oder
+Reviewer-Empfehlung gefunden — inhaltlich unbedenklich, aber eine formale
+Re-Review-Runde wäre nach Workflow-Buchstaben der sauberere Weg gewesen.
+Kein Blocker für dieses kleine, nachträglich verifizierte Detail.
+
+---
+
+## 3. Review-Befunde (`task-T01.review.md`)
+
+**Muss:** keine gemeldet.
+
+**Sollte (2 Befunde):**
+
+1. Englische Test-Beschreibungen in `settings.test.ts` statt des im
+   Frontend-Testbestand etablierten deutschen Musters — **bewusst nicht
+   umgesetzt**. Nicht blockierend laut Reviewer selbst ("kann diskutiert
+   werden"), betrifft nur Lesbarkeit/Konsistenz, keine Funktionalität.
+   Akzeptabel dokumentiert zu lassen, siehe Auftrag Punkt 3.
+2. `_method`-Feld per `.append()` vor der Schleife statt robusterem
+   `.set()` nach der Schleife — **umgesetzt**, siehe Abschnitt 2 oben.
+   Per eigenem `git diff` verifiziert: exakt der vom Reviewer vorgeschlagene
+   Code (`formData.set('_method', 'PUT')` nach `forEach`).
+
+**Könnte:** zwei rein informative Punkte (Kommentar-Duplikation zu
+`design.md`, fehlender `boundary`-Parameter im Header, letzteres außerhalb
+des Diffs) — beide ohne Handlungsbedarf laut Reviewer selbst, keine
+Nacharbeit nötig.
+
+---
+
+## 4. Testergebnisse
+
+Eigenständig im `frontend/`-Verzeichnis erneut ausgeführt (nicht nur auf
+Aussage des Orchestrators verlassen):
+
+```
+$ npx vitest run src/api/settings.test.ts
+ Test Files  1 passed (1)
+      Tests  10 passed (10)
+
+$ npm run test -- --run
+ Test Files  11 passed (11)
+      Tests  121 passed (121)
+
+$ npm run build
+> vue-tsc -b && vite build
+✓ 636 modules transformed.
+✓ built in 1.33s
+(keine Fehler, keine Warnings im Output)
+```
+
+Ergebnis deckt sich mit den Angaben aus `task-T01.test-report.md`
+(121 Tests, `alle-gruen`) und der Aussage des Orchestrators (10/10 in
+`settings.test.ts`, Build fehlerfrei) — beides eigenständig bestätigt,
+nicht nur übernommen.
+
+**Ungetestete Akzeptanzkriterien:** keine. Alle funktionalen Kriterien aus
+`tasks.md` sind durch Tests in `settings.test.ts` abgedeckt (Methode,
+Endpunkt, Header, `_method`-Feld, Text-/Datei-Felder, Skip von
+`null`/`undefined`, plus vier vom Tester ergänzte Grenzfälle: leeres
+Argument, Logo+Favicon gleichzeitig, Nicht-String-Primitives, Rückgabewert).
+Das einzige nicht ausführbare Kriterium (`npm run lint`) ist strukturell
+bedingt (Script existiert nicht) und kein Test-, sondern ein
+Tooling-Lücken-Thema außerhalb des Scopes.
+
+---
+
+## Erfüllt
+
+- Alle T01-Akzeptanzkriterien erfüllt (bis auf das nicht-existente
+  `lint`-Script, dokumentiert und nicht blockierend).
+- `openspec validate --strict` erfolgreich.
+- Spec-Deltas (`specs/settings-file-upload-transport/spec.md`) korrekt im
+  Code umgesetzt, inklusive der nachträglichen, robusteren
+  `.set()`-nach-der-Schleife-Variante.
+- Beide "Sollte"-Reviewbefunde behandelt (einer umgesetzt, einer bewusst
+  und nachvollziehbar zurückgestellt).
+- Alle Tests grün (121/121 Frontend, davon 10/10 neu in
+  `settings.test.ts`), Build fehlerfrei — von mir eigenständig
+  nachvollzogen, nicht nur übernommen.
+- Kein Backend-Code angefasst, wie im Scope vorgesehen.
+
+## Offen / Nacharbeit (nicht blockierend)
+
+- `tasks.md`, Akzeptanzkriterium 1: Wortlaut nennt noch `formData.append(...)`
+  vor der Schleife, tatsächlicher Code nutzt jetzt `formData.set(...)` nach
+  der Schleife (funktional gleichwertig, spec-konform). Redaktionelle
+  Auffrischung empfohlen, kein Merge-Blocker.
+- Die nachträgliche `.set()`-Korrektur wurde außerhalb des regulären
+  `dev-javascript`-Review-Zyklus eingespielt und dadurch nicht noch einmal
+  formal vom Reviewer gegengelesen. Ich habe das als Architekt eigenständig
+  verifiziert (Diff, Tests, Build); für zukünftige manuelle
+  Zwischenkorrekturen empfiehlt sich dennoch, den regulären
+  Dev-Review-Zyklus einzuhalten, um diese Lücke zu vermeiden.
+
+## Empfehlung an den User
+
+Der Change ist inhaltlich, spec- und testseitig abnahmereif; beide offenen
+Punkte sind rein redaktionell/prozessual und blockieren nicht. Empfehlung:
+Freigabe erteilen und mit Schritt 13 (`openspec archive`) fortfahren.

--- a/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/design.md
+++ b/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/design.md
@@ -1,0 +1,265 @@
+# Design: fix-settings-upload-put-multipart
+
+## Architekturübersicht
+
+Ein einzelner, isolierter Fix in einer Frontend-API-Funktion. Keine
+Abhängigkeit zu anderen Modulen außer dem bereits vorhandenen
+`apiClient` (`frontend/src/api/client.ts`) und der bestehenden Backend-Route.
+Keine Schema-, keine DB-Änderung.
+
+---
+
+## Root-Cause-Analyse
+
+**Datei:** `frontend/src/api/settings.ts:35-54`
+
+```ts
+async updateSettings(settings: Record<string, any>) {
+  const formData = new FormData()
+  Object.entries(settings).forEach(([key, value]) => {
+    if (value !== null && value !== undefined) {
+      if (value instanceof File) {
+        formData.append(key, value)
+      } else {
+        formData.append(key, String(value))
+      }
+    }
+  })
+
+  const response = await apiClient.put<SettingsResponse>('/api/v1/settings', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return response.data
+},
+```
+
+`apiClient.put(...)` (Axios) sendet ein echtes HTTP-`PUT` mit
+`Content-Type: multipart/form-data`. PHP füllt `$_POST` und `$_FILES` nur
+bei der SAPI-Methode `POST` automatisch. Bei `PUT`/`PATCH`/`DELETE` hängt
+die Body-Parsung von Symfonys `Request::createFromGlobals()`
+(`backend/vendor/symfony/http-foundation/Request.php:286-312`) ab: erst ab
+`PHP_VERSION_ID >= 80400` wird der Body generisch über die native
+PHP-8.4-Funktion `request_parse_body()` geparst (inkl. Multipart/Dateien).
+Auf PHP < 8.4 bleiben `$_POST` und `$_FILES` für `PUT`-Requests leer — die
+Felder und Dateien gehen ohne Fehlermeldung verloren, weil alle Regeln in
+`UpdateSettingsRequest::rules()`
+(`backend/app/Http/Requests/UpdateSettingsRequest.php:32-59`) mit
+`sometimes`/`nullable` beginnen: ein fehlendes Feld ist aus Validierungssicht
+kein Fehler.
+
+`backend/app/Http/Controllers/SettingsController.php:37-79` prüft korrekt
+per `$request->hasFile($key)` (Zeile 45) — das Problem liegt ausschließlich
+davor, in der Body-Parsung durch PHP/Symfony, nicht im Anwendungscode des
+Controllers.
+
+---
+
+## Widerspruch: Bug tritt auch in Produktion auf
+
+Die ursprüngliche Triage-Annahme war: Produktion läuft laut CLAUDE.md
+Abschnitt 3 auf PHP 8.4 (`docker/php/Dockerfile:1` →
+`FROM php:8.4-fpm-alpine` für die lokale/Docker-Referenzumgebung), also
+sollte `request_parse_body()` dort den Multipart-PUT-Body korrekt parsen
+und der Bug auf Produktion nicht auftreten. Der User berichtet jedoch
+ausdrücklich, dass der Effekt **auch in Produktion** auftritt.
+
+**Befund aus der Code-Prüfung — konkrete, im Repo nachweisbare Ursache für
+den Widerspruch:**
+
+Es gibt **zwei widersprüchliche PHP-Versionsprüfungen** für den
+Shared-Hosting-Weg im Repo selbst:
+
+1. `backend/requirements-check.php:18` (Kommentar) und `:58-60` (Logik):
+   ```php
+   if ($major < 8 || ($major == 8 && $minor < 4)) {
+       $results['php_version']['status'] = 'fail';
+       $results['php_version']['message'] = 'PHP 8.4.0 or higher is required';
+   ```
+   Dieses Skript verlangt hart PHP `>= 8.4` und lehnt alles darunter ab.
+   Es ist aber ein **optionales, manuell hochzuladendes Diagnose-Tool**
+   (siehe Kopfkommentar `requirements-check.php:1-19`: "Upload this file
+   ... DELETE THIS FILE after successful installation") — es wird nicht
+   zwingend ausgeführt.
+
+2. `install.php:851-863` (`checkServerRequirements()`), der Installer, der
+   laut `DEPLOYMENT.md` Schritt 2 ("Schritt 2: Server-Anforderungen") den
+   eigentlichen, dokumentierten Installationsweg für Shared Hosting bildet:
+   ```php
+   'php_version' => [
+       'required' => '8.2',
+       'current' => PHP_VERSION,
+       'status' => version_compare(PHP_VERSION, '8.2.0', '>=') ? 'pass' : 'fail'
+   ],
+   ```
+   Dieser **tatsächlich verwendete** Installer akzeptiert PHP `>= 8.2` ohne
+   Warnung (`status: 'pass'`) und lässt die Installation ungehindert
+   fortsetzen (`$canProceed` wird nicht durch die PHP-Version blockiert,
+   solange `>= 8.2`).
+
+`DEPLOYMENT.md:19,105,268,424,447` und `PRODUCTION-SETUP.md:13` behaupten
+"PHP 8.4 erforderlich" bzw. nennen 8.4 als Ziel-Version — das ist jedoch
+reine Dokumentation, **nicht durch den tatsächlich benutzten Installer
+erzwungen**. Ein Shared-Hosting-Kunde (konkret: die in
+`PRODUCTION-SETUP.md:1-15` beschriebene Installation auf
+`www.leisoft.de`, PHP laut Dokument "8.4") kann den Installations-Assistenten
+klaglos auf einem Hoster durchlaufen, dessen tatsächliche PHP-Version im
+Control-Panel auf 8.2 oder 8.3 steht — der Installer meldet dort `pass`,
+nicht `fail` oder auch nur `warning`. Da Shared-Hosting-Anbieter PHP-Versionen
+über ein Control-Panel setzen (vgl. CLAUDE.md Abschnitt 3, "Verschiedene
+Shared-Hosting-Anbieter führen unterschiedliche PHP-Versionen"), ist es
+plausibel, dass die tatsächlich konfigurierte Produktions-PHP-Version von
+der in `PRODUCTION-SETUP.md` dokumentierten Absicht (8.4) abweicht, ohne
+dass dies irgendwo im Installationsprozess auffällt.
+
+**Einordnung:** Damit erklärt sich der Widerspruch am plausibelsten durch
+Erklärung 1 aus dem Architekten-Auftrag ("tatsächlich laufende PHP-Version
+weicht von der CLAUDE.md-Matrix/Dokumentation ab") — mit einer konkreten,
+im Code nachweisbaren Ursache dafür: der produktiv genutzte Installer
+(`install.php`) prüft nur auf `>= 8.2`, nicht auf `>= 8.4`, im Widerspruch
+zu `requirements-check.php` und den Markdown-Dokumenten. Ob zusätzlich
+Erklärung 2 (Symfony-/`request_parse_body()`-Edge-Cases auch unter 8.4) oder
+Erklärung 3 (Reverse-Proxy/.htaccess-Eigenheiten) eine Rolle spielen, lässt
+sich ohne Zugriff auf die konkrete Produktionsumgebung nicht abschließend
+verifizieren — für den Fix ist das aber irrelevant (siehe nächster
+Abschnitt).
+
+**Konsequenz für diesen Change:** Die Lösung darf sich **nicht** auf die
+Annahme "betrifft nur PHP < 8.4" stützen. Sie muss unabhängig von der
+tatsächlichen PHP-Version in jeder Umgebung (Entwicklung, Demo, Produktion)
+funktionieren.
+
+---
+
+## Lösungsansatz: POST + Method-Override statt echtem PUT
+
+**Datei:** `frontend/src/api/settings.ts:35-54`
+
+```ts
+async updateSettings(settings: Record<string, any>) {
+  const formData = new FormData()
+  formData.append('_method', 'PUT')
+
+  Object.entries(settings).forEach(([key, value]) => {
+    if (value !== null && value !== undefined) {
+      if (value instanceof File) {
+        formData.append(key, value)
+      } else {
+        formData.append(key, String(value))
+      }
+    }
+  })
+
+  const response = await apiClient.post<SettingsResponse>('/api/v1/settings', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return response.data
+},
+```
+
+Änderungen im Detail:
+1. `apiClient.put(...)` → `apiClient.post(...)`.
+2. Zusätzliches `FormData`-Feld `_method` mit Wert `'PUT'` (Laravels
+   Konvention für Method-Spoofing).
+
+### Warum das PHP-versionsunabhängig funktioniert
+
+Der Request kommt jetzt als echtes HTTP-`POST` mit
+`multipart/form-data`-Body an. PHP füllt `$_POST`/`$_FILES` bei `POST` immer
+nativ, unabhängig von der PHP-Version — das ist SAPI-Standardverhalten seit
+PHP 4 und hat nichts mit `request_parse_body()` (PHP 8.4) zu tun. Laravels
+`Illuminate\Foundation\Http\Kernel::handle()` ruft
+`$request->enableHttpMethodParameterOverride()` auf
+(`backend/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:143`),
+**bevor** der Request geroutet wird. Symfonys
+`Request::getMethod()`/`Request::setMethod()`-Override-Mechanismus liest
+dafür das `_method`-Feld aus dem geparsten `$_POST`-Body und behandelt den
+Request intern als `PUT` — der Router matcht also weiterhin gegen
+`Route::put('/settings', [SettingsController::class, 'update'])`
+(`backend/routes/api.php:195`), ohne dass Route oder Controller geändert
+werden müssen.
+
+Damit ist der Fix unabhängig davon, ob die tatsächliche Produktions-PHP-Version
+8.2, 8.3 oder 8.4 ist, und unabhängig davon, ob die in "Widerspruch"
+beschriebene Installer-Inkonsistenz behoben wird oder nicht — der Fix
+umgeht die eigentliche Fehlerquelle (PUT + Multipart-Body-Parsing) komplett,
+statt sich auf eine bestimmte PHP-Version zu verlassen.
+
+### Warum keine Backend-Änderung nötig ist
+
+- Die Route bleibt `PUT` (`backend/routes/api.php:195`) — das ist korrekt
+  und muss nicht geändert werden, weil Laravel das Override vor dem Routing
+  anwendet.
+- `SettingsController::update(UpdateSettingsRequest $request)`
+  (`backend/app/Http/Controllers/SettingsController.php:37`) erhält
+  weiterhin ein `Request`-Objekt, bei dem `$request->method()` `'PUT'`
+  zurückgibt (durch das Override), `$request->hasFile($key)` funktioniert
+  unverändert.
+- `UpdateSettingsRequest` benötigt keine Anpassung — Method-Override
+  betrifft nur die HTTP-Methode, nicht die Validierungsregeln.
+
+---
+
+## Kompatibilitätsprüfung (CLAUDE.md Abschnitt 3/4)
+
+- **PHP-Kompatibilität:** Keine PHP-Code-Änderung in diesem Change. Der Fix
+  wirkt rein auf Transport-Ebene (Frontend). Betrifft PHP 8.2, 8.3, 8.4
+  identisch (siehe oben).
+- **DB-Kompatibilität:** Keine DB-Änderung, kein raw SQL, keine Migration.
+  Nicht zutreffend.
+- **Shared-Hosting:** Kein neues Server-Feature nötig, kein Cron, keine
+  Queue, kein Worker. Method-Override ist reines Laravel-Framework-Verhalten,
+  bereits aktiv.
+- **Frontend/Vite:** Keine neue Abhängigkeit, keine Build-Konfigurationsänderung.
+
+---
+
+## Test-Strategie
+
+### In diesem Change umgesetzt
+
+**Vitest-Test** für `settingsApi.updateSettings()`
+(`frontend/src/api/settings.test.ts`, neu): mockt `@/api/client` (Muster wie
+in `frontend/src/views/CourseDetailView.test.ts:16-30`) und prüft:
+- `apiClient.post` wird aufgerufen (nicht `apiClient.put`).
+- Das `FormData`-Objekt im Aufruf enthält ein Feld `_method` mit Wert
+  `'PUT'`.
+- Datei- und Text-Felder landen weiterhin korrekt im `FormData`.
+
+### Bewusst nicht in diesem Change umgesetzt (Empfehlung für später)
+
+Die bestehenden Pest-Tests in
+`backend/tests/Feature/Api/SettingsValidationTest.php` verwenden Laravels
+`->putJson(...)`-Helper. Dieser baut das `Illuminate\Http\Request`-Objekt
+direkt im Prozess auf (`Illuminate\Foundation\Testing\Concerns\MakesHttpRequests`)
+und durchläuft **nicht** `Request::createFromGlobals()` bzw. die reale
+PHP-SAPI-Body-Parsung — solche Tests bleiben grün, unabhängig von der
+PHP-Version und unabhängig von dieser ganzen Bug-Klasse. Sie sind also
+weder ein Nachweis dafür, dass der ursprüngliche Bug bestand, noch dass der
+Fix wirkt.
+
+**Empfehlung (nicht Teil dieses Changes):** Ein echter HTTP-Ebenen-Test, der
+die reale Server-Verarbeitung abbildet — z. B. ein Test, der einen
+laufenden PHP-Built-in-Server oder PHP-FPM-Prozess über einen echten HTTP-Client
+(cURL/Guzzle) anspricht, statt Laravels In-Prozess-Test-Client zu verwenden,
+oder ein Playwright-/Browser-E2E-Test gegen die Docker-Umgebung. Das ist ein
+eigenständiges Test-Infrastruktur-Thema (neue Test-Kategorie, ggf. neue
+CI-Pipeline-Stufe) und sprengt den Rahmen dieses kleinen Bugfix-Changes —
+siehe `proposal.md`, Abschnitt "Offene Punkte für den Skeptiker".
+
+---
+
+## Entwurfsmuster-Bezug
+
+- **KISS:** Minimalinvasiver Fix auf Transport-Ebene, keine neue
+  Abstraktion, keine Interceptor-Logik in `client.ts` für alle Requests
+  (das wäre unnötige globale Kopplung für ein Problem, das nur einen
+  einzigen Upload-Pfad betrifft).
+- **YAGNI:** Keine generische "Multipart-PUT-zu-POST"-Middleware in
+  `apiClient` gebaut, obwohl das denkbar wäre — aktuell gibt es nur einen
+  betroffenen Call-Site (`settings.ts`). Falls künftig weitere
+  PUT+Multipart-Fälle entstehen, kann diese Middleware bei Bedarf
+  extrahiert werden (Boy-Scout-Prinzip, nicht vorab spekulativ).
+- **Single Responsibility:** `settingsApi.updateSettings()` bleibt allein
+  dafür zuständig, Settings-Daten korrekt zu serialisieren und zu senden;
+  die Transport-Fix-Logik gehört genau dorthin, nicht in eine
+  projektweite Axios-Konfiguration.

--- a/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/proposal.md
+++ b/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/proposal.md
@@ -1,0 +1,116 @@
+# Proposal: fix-settings-upload-put-multipart
+
+**Change-ID:** fix-settings-upload-put-multipart
+**Typ:** Bugfix
+**Pfad:** klein
+**Status:** entwurf
+
+---
+
+## Was wird geändert?
+
+`settingsApi.updateSettings()` in `frontend/src/api/settings.ts:35-54` sendet
+Firmenlogo, Favicon und alle übrigen Settings-Felder aktuell als
+`multipart/form-data`-Body via echtem HTTP-`PUT`
+(`apiClient.put('/api/v1/settings', formData, …)`, Zeile 48).
+
+Der Fix ändert den Transportweg auf ein HTTP-`POST` mit Laravels
+Method-Override-Konvention: Der `FormData` erhält ein zusätzliches Feld
+`_method=PUT`, und der Request wird via `apiClient.post(...)` statt
+`apiClient.put(...)` gesendet. Route, Controller (`SettingsController::update()`,
+`backend/app/Http/Controllers/SettingsController.php:37-79`) und
+`UpdateSettingsRequest` (`backend/app/Http/Requests/UpdateSettingsRequest.php`)
+bleiben unverändert — Laravel wendet das Method-Override
+(`$request->enableHttpMethodParameterOverride()`,
+`backend/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:143`)
+vor dem Routing an, sodass die Route `PUT /api/v1/settings`
+(`backend/routes/api.php:195`) weiterhin korrekt matcht.
+
+---
+
+## Warum wird es geändert?
+
+Der Admin lädt Firmenlogo oder Favicon in den Einstellungen hoch und drückt
+Speichern — die Datei "verschwindet" kommentarlos, ohne Fehlermeldung, weil
+alle Felder in `UpdateSettingsRequest` `sometimes`/`nullable` sind.
+
+**Root Cause (siehe Triage
+`openspec/triage/20260701195331-settings-upload-put-multipart-lost.md` und
+`design.md` dieses Changes):** PHP befüllt `$_POST`/`$_FILES` nativ nur bei
+der HTTP-Methode `POST`. Für echte `PUT`-Requests mit
+`multipart/form-data`-Body hängt die korrekte Body-Parsung von der
+PHP-Version ab (`request_parse_body()`, verfügbar erst ab PHP 8.4) — und,
+wie die Prüfung für diesen Change ergeben hat, zusätzlich vom tatsächlichen
+Server-Setup, das von der CLAUDE.md-Matrix abweichen kann (Details siehe
+`design.md`, Abschnitt "Widerspruch: Bug tritt auch in Produktion auf").
+
+**Wichtig — der Fix ist unabhängig davon, welche PHP-Version tatsächlich in
+Produktion läuft.** Er wechselt lediglich die Transportmethode (POST statt
+PUT), sodass PHP `$_POST`/`$_FILES` in jedem Fall nativ befüllt — unabhängig
+von PHP-Version, `request_parse_body()`-Verfügbarkeit oder sonstigen
+Body-Parsing-Eigenheiten des jeweiligen Hosters.
+
+---
+
+## Umfang
+
+| Bereich | Datei | Art |
+|---------|-------|-----|
+| Frontend | `frontend/src/api/settings.ts` | Änderung (Methode + FormData-Feld) |
+| Frontend | `frontend/src/api/settings.test.ts` | Neu (Vitest) |
+
+Kein Backend-Code ist zwingend nötig — Route, Controller und
+`UpdateSettingsRequest` funktionieren mit Method-Override bereits korrekt
+(siehe `design.md`, Abschnitt "Warum keine Backend-Änderung nötig ist").
+
+---
+
+## Offene Punkte für den Skeptiker
+
+1. **Prod/PHP-Diskrepanz — Dokumentations-Inkonsistenz im Repo selbst:**
+   Bei der Code-Prüfung für diesen Change wurde ein Widerspruch zwischen
+   zwei Server-Anforderungsprüfungen im Repo gefunden:
+   - `backend/requirements-check.php:58-60` verlangt hart PHP `>= 8.4`
+     (`status = 'fail'` sonst).
+   - `install.php:851-863` (`checkServerRequirements()`, tatsächlich vom
+     Shared-Hosting-Installer aus `DEPLOYMENT.md` Schritt 3.2 aufgerufen)
+     verlangt nur PHP `>= 8.2` (`'required' => '8.2'`,
+     `version_compare(PHP_VERSION, '8.2.0', '>=')`).
+
+   Das bedeutet: Eine reale Shared-Hosting-Installation über den
+   dokumentierten Installer-Weg kann **klaglos auf PHP 8.2 oder 8.3**
+   abgeschlossen werden, obwohl `DEPLOYMENT.md` und
+   `PRODUCTION-SETUP.md` PHP 8.4 als Ziel nennen. Das erklärt plausibel,
+   warum der User den Bug auch "in Produktion" beobachtet hat — die
+   tatsächlich installierte PHP-Version auf dem konkreten Hoster
+   (`PRODUCTION-SETUP.md:13`: `www.leisoft.de`) wurde nicht durch das
+   Repo selbst erzwungen oder verifiziert.
+   **Empfehlung an den Skeptiker/User:** zu klären, ob
+   `install.php:857` auf `8.4.0` angehoben werden soll, damit Installer
+   und `requirements-check.php` konsistent sind — das wäre aber ein
+   **eigener, unabhängiger Change** (Infra/Deployment-Thema, nicht Teil
+   dieses Bugfixes) und wird hier bewusst nicht mit-repariert (YAGNI /
+   Scope-Trennung).
+2. **Test-Lücke bei künftigen PUT+Multipart-Regressionen:** Die bestehenden
+   Pest-`putJson`-Tests in
+   `backend/tests/Feature/Api/SettingsValidationTest.php` durchlaufen
+   Laravels In-Prozess-Test-Client und **nicht**
+   `Request::createFromGlobals()` — sie hätten diesen Bug nie erkannt und
+   werden es strukturell auch künftig nicht tun. Ein echter
+   HTTP-Ebenen-Test (z. B. gegen einen laufenden PHP-Built-in-Server oder
+   via Browser-/E2E-Test) wäre nötig, um diese Bug-Klasse dauerhaft
+   abzusichern. Das ist als Empfehlung in `design.md` dokumentiert, aber
+   **nicht Teil dieses kleinen Changes** — Umsetzung würde eine neue
+   Test-Infrastruktur-Kategorie einführen und sprengt den Rahmen eines
+   "kleinen" Fixes.
+
+## Nicht im Scope
+
+- Keine Änderung an Backend-Validierung oder Datenmodell.
+- Keine Änderung an `frontend/src/api/trainingAttachments.ts` (verwendet
+  bereits korrekt `POST`, ist nicht betroffen).
+- Keine Erhöhung der Mindest-PHP-Version im Installer (`install.php`) oder
+  Vereinheitlichung mit `requirements-check.php` — siehe "Offene Punkte"
+  oben.
+- Keine neue HTTP-Ebenen-Test-Infrastruktur (Playwright o. ä.) — nur
+  Empfehlung, kein Umsetzungsauftrag in diesem Change.

--- a/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/specs/settings-file-upload-transport/spec.md
+++ b/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/specs/settings-file-upload-transport/spec.md
@@ -1,0 +1,81 @@
+# Spec: settings-file-upload-transport
+
+**Status:** ADDED
+**Capability:** Transportweg für Datei-Uploads beim Speichern der Systemeinstellungen
+
+---
+
+## Purpose
+
+Wenn der Admin Systemeinstellungen speichert, die Dateien enthalten
+(Firmenlogo, Favicon), muss der Request so an das Backend übertragen
+werden, dass PHP den Request-Body inklusive Dateien zuverlässig auswertet
+— unabhängig von der auf dem Server laufenden PHP-Version (8.2, 8.3 oder
+8.4) und unabhängig davon, ob echte HTTP-PUT-Requests mit
+`multipart/form-data`-Body auf dem jeweiligen Server korrekt geparst
+werden. Das Backend muss die Anfrage weiterhin als logisches `PUT`
+behandeln (Autorisierung, Validierung, Idempotenz-Semantik unverändert).
+
+---
+
+## ADDED Requirements
+
+### Requirement: Settings-Update wird als POST mit Method-Override gesendet
+
+Der Frontend-Client SHALL Settings-Update-Requests (`PUT /api/v1/settings`),
+die potenziell Dateien enthalten, als HTTP-`POST` mit einem zusätzlichen
+`FormData`-Feld `_method=PUT` senden, statt ein echtes HTTP-`PUT` mit
+`multipart/form-data`-Body zu verwenden. Damit befüllt PHP `$_POST` und
+`$_FILES` in jeder unterstützten PHP-Version (8.2, 8.3, 8.4) zuverlässig,
+weil `POST` von der SAPI immer nativ geparst wird, unabhängig von
+`request_parse_body()`-Verfügbarkeit oder sonstigen Server-Eigenheiten.
+Das Backend MUSS den Request weiterhin fachlich als `PUT` behandeln
+(Routing, Autorisierung, Validierung unverändert) — Laravels
+Method-Override-Mechanismus übernimmt das vor dem Routing.
+
+#### Scenario: Update ohne Datei
+- **GIVEN** der Admin ändert nur Textfelder (z. B. `company_name`) in den
+  Einstellungen und enthält keine Datei
+- **WHEN** das Formular gespeichert wird
+- **THEN** der Client sendet ein HTTP-`POST` an `/api/v1/settings`
+- **AND** der `FormData`-Body enthält ein Feld `_method` mit dem Wert `PUT`
+- **AND** das Backend behandelt die Anfrage als `PUT` (Autorisierung via
+  `SettingsController::update()` greift wie bisher)
+
+#### Scenario: Update mit Firmenlogo
+- **GIVEN** der Admin wählt eine neue Logo-Datei aus
+- **WHEN** das Formular gespeichert wird
+- **THEN** der Client sendet ein HTTP-`POST` an `/api/v1/settings` mit
+  `Content-Type: multipart/form-data`
+- **AND** der `FormData`-Body enthält sowohl das Feld `_method=PUT` als
+  auch die Logo-Datei unter ihrem Feldnamen (z. B. `company_logo`)
+- **AND** die Datei kommt serverseitig zuverlässig in `$request->hasFile('company_logo')`
+  an — unabhängig von der PHP-Version des Servers
+
+#### Scenario: Update mit Favicon
+- **GIVEN** der Admin wählt eine neue Favicon-Datei aus (PNG oder ICO)
+- **WHEN** das Formular gespeichert wird
+- **THEN** gilt dieselbe Übertragungslogik wie beim Firmenlogo (POST +
+  `_method=PUT` + Datei im `FormData`)
+
+#### Scenario: Server-seitiges Routing bleibt unverändert
+- **GIVEN** ein POST-Request mit `_method=PUT` im `FormData`-Body erreicht
+  das Backend
+- **WHEN** Laravel den Request verarbeitet
+- **THEN** die Route `PUT /api/v1/settings` matcht weiterhin (Method-Override
+  wird vor dem Routing angewendet)
+- **AND** `SettingsController::update()` erhält den Request unverändert wie
+  bei einem echten `PUT`-Request
+
+---
+
+## Nicht Teil dieser Spec
+
+- Validierungsregeln für einzelne Settings-Felder (siehe Capability
+  `settings-favicon-upload` für die MIME-/Größenregeln von
+  `company_favicon`).
+- Verhalten des Frontend-Formulars bei Speicherfehlern (siehe ebenfalls
+  `settings-favicon-upload`).
+- Serverseitige PHP-Versionsanforderungen für Deployment/Installer — das
+  ist Gegenstand der offenen Punkte in `proposal.md` dieses Changes und
+  potenziell eines eigenen, künftigen Changes.

--- a/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/task-T01.notes.md
+++ b/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/task-T01.notes.md
@@ -1,0 +1,88 @@
+# Task T01 — Notes (dev-javascript)
+
+## Umsetzung
+
+### `frontend/src/api/settings.ts` (Zeilen 35-62)
+
+- `formData.append('_method', 'PUT')` direkt nach `new FormData()` und vor
+  dem Befüllen der Text-/Datei-Felder ergänzt.
+- `apiClient.put<SettingsResponse>(...)` durch
+  `apiClient.post<SettingsResponse>(...)` ersetzt. Pfad (`/api/v1/settings`)
+  und Header (`Content-Type: multipart/form-data`) unverändert übernommen.
+- Kurzer Kommentar über dem `apiClient.post`-Aufruf ergänzt, der den Root
+  Cause (PHP befüllt `$_POST`/`$_FILES` nur zuverlässig bei echtem POST) und
+  den Method-Override-Mechanismus referenziert, damit der Zusammenhang beim
+  Lesen des Codes ohne Blick in `design.md` nachvollziehbar bleibt.
+- Die restliche Logik (Iteration über `Object.entries(settings)`, Skip von
+  `null`/`undefined`, `File`-Erkennung via `instanceof File`, `String(value)`
+  für alle anderen Werte) ist unverändert geblieben — kein
+  Verhaltensunterschied außer Methode + neues `_method`-Feld, wie gefordert.
+- Backend (`backend/routes/api.php:195`, `Route::put('/settings', ...)`)
+  wurde nicht angefasst, wie in der Task-Beschreibung vorgesehen.
+
+### `frontend/src/api/settings.test.ts` (neu)
+
+- `@/api/client` gemockt nach dem Muster aus
+  `frontend/src/views/CourseDetailView.test.ts:16-22` (Default-Export als
+  Objekt mit `vi.fn()`-Methoden; hier `get`, `post`, `put`).
+- 6 Tests:
+  1. `apiClient.post` wird genau einmal aufgerufen, `apiClient.put` gar nicht.
+  2. Pfad `/api/v1/settings` und `Content-Type: multipart/form-data`-Header
+     werden korrekt übergeben.
+  3. `_method=PUT` ist im übergebenen `FormData` vorhanden
+     (`formData.get('_method') === 'PUT'`).
+  4. Text-Feld (`company_name`) landet unverändert im `FormData`.
+  5. Ein `File`-Objekt landet unverändert (gleicher Dateiname) im `FormData`.
+  6. `null`/`undefined`-Werte werden weiterhin übersprungen
+     (`formData.has(...) === false`).
+- `vi.mocked(apiClient.post).mock.calls[0]` wird mit einem Non-null-Assertion
+  (`!`) destrukturiert, da `noUncheckedIndexedAccess: true` (aus
+  `@vue/tsconfig`) den Array-Zugriff sonst als `T | undefined` typisiert.
+  Gleiches Muster existiert bereits in
+  `frontend/src/composables/usePricingItems.test.ts:155`.
+
+## Testergebnisse
+
+Alle Befehle liefen in der lokalen Node/npm-Umgebung im `frontend/`-Verzeichnis
+(kein Docker-Frontend-Service in `docker-compose.yml` vorhanden — Frontend-Tests
+laufen projektüblich per npm auf dem Host, nicht im PHP/MySQL-Docker-Setup aus
+Abschnitt 7.1 der `CLAUDE.md`, das sich auf Backend-Tests bezieht).
+
+```
+npm run test -- --run
+  Test Files  11 passed (11)
+  Tests  117 passed (117)
+
+npm run build
+  vue-tsc -b && vite build   → 0 Fehler, 0 Warnings
+```
+
+Neue Datei einzeln geprüft: `npx vitest run src/api/settings.test.ts` →
+6 passed (6).
+
+## Abweichung: `npm run lint`
+
+`frontend/package.json` enthält aktuell **kein** `lint`-Script (`scripts`
+umfasst nur `dev`, `build`, `build:deploy`, `preview`, `test`, `test:ui`,
+`test:coverage`, `e2e`, `e2e:ui`), und es existiert keine ESLint-Konfigurations-
+datei im `frontend/`-Verzeichnis. `npm run lint` kann daher nicht ausgeführt
+werden — das ist ein bestehender Zustand des Projekts, unabhängig von dieser
+Task, und wird hier nur dokumentiert, nicht behoben (Scope dieser Task ist
+ausschließlich T01 lt. `tasks.md`). Typprüfung erfolgt stattdessen weiterhin
+über `vue-tsc -b` als Teil von `npm run build`, das ohne Fehler/Warnings
+durchläuft.
+
+## Nebenbefund: Umgebungsproblem `node_modules`
+
+Vor dem ersten Testlauf schlug `npx vitest` mit einem esbuild-Plattform-
+fehler fehl (`@esbuild/linux-arm64` installiert statt `@esbuild/darwin-arm64`
+auf dieser macOS-arm64-Maschine). Behoben durch `npm install` im
+`frontend/`-Verzeichnis, wodurch die korrekten optionalen Plattform-Pakete
+nachinstalliert wurden (3 Pakete entfernt, 3 hinzugefügt). Kein
+Code-/Lockfile-Unterschied, reines lokales Artefakt-Problem — `package.json`
+und `package-lock.json` sind laut `git status` unverändert geblieben.
+
+## Keine Abweichungen von der Spec
+
+Implementierung entspricht 1:1 der Task-Beschreibung und den
+Akzeptanzkriterien aus `tasks.md`.

--- a/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/task-T01.review.md
+++ b/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/task-T01.review.md
@@ -1,0 +1,83 @@
+# Review: T01
+
+**Gesamtempfehlung:** ok
+
+## Muss (blockiert Abnahme)
+
+Keine.
+
+## Sollte (vor Merge erledigen, kann diskutiert werden)
+
+- **[Konsistenz]** `frontend/src/api/settings.test.ts:19,26,34,42,49,60`: Die
+  `it(...)`-Beschreibungen sind auf Englisch formuliert
+  (`'sends the request via apiClient.post, not apiClient.put'`,
+  `'appends a _method=PUT field to the FormData for method override'`, …).
+  Bestehende Vitest-Tests im selben Projekt verwenden durchgängig deutsche,
+  dritte-Person-Indikativ-Beschreibungen, z. B.
+  `frontend/src/views/CourseDetailView.test.ts:128`:
+  `it('zeigt den Lade-Spinner während loadCourse läuft', …)` und
+  `frontend/src/composables/usePricingItems.test.ts:34`:
+  `it('befüllt groups bei Erfolg, setzt loading auf false und error auf null', …)`.
+  `TESTING.md` Abschnitt 2.1 schreibt dieses Format zwar mit Pest-Beispielen
+  vor, das Prinzip (Deutsch, 3. Person, Verb-first) ist aber im
+  Frontend-Testbestand ebenso durchgehend etabliert. Vorschlag: Beschreibungen
+  auf Deutsch umformulieren, z. B. `'sendet die Anfrage über apiClient.post,
+  nicht apiClient.put'`.
+
+- **[Korrektheit/Robustheit]** `frontend/src/api/settings.ts:37-47`: Das
+  Method-Override-Feld wird per `formData.append('_method', 'PUT')` **vor**
+  der `forEach`-Schleife gesetzt, die anschließend beliebige Schlüssel aus dem
+  übergebenen `settings: Record<string, any>` anhängt. Sollte `settings`
+  jemals einen Schlüssel `_method` enthalten (aktuell nicht der Fall, siehe
+  `frontend/src/views/SettingsView.vue:625-641` — `settings` wird aus dem
+  Vue-`formData`-Ref mit fest kodierten Property-Namen aufgebaut, `_method`
+  taucht dort nie auf), würde ein zweiter `_method`-Eintrag im FormData
+  landen. Da PHP beim Parsen von `multipart/form-data`-Bodies bei doppelten
+  Feldnamen den zuletzt vorkommenden Wert in `$_POST` gewinnen lässt ("last
+  wins"), würde ein caller-kontrollierter `_method`-Wert den beabsichtigten
+  `'PUT'`-Override stillschweigend überschreiben. Die Funktionssignatur
+  (`Record<string, any>`) gibt aber keine Garantie, dass `_method` nie als
+  Schlüssel vorkommt — genau diese Art von "kein Fehler, Daten verschwinden
+  nur leise" ist der Bug-Klasse, die dieser Change gerade behebt. Vorschlag:
+  `_method` per `formData.set('_method', 'PUT')` **nach** der Schleife setzen
+  (statt `.append()` davor), damit der Override-Wert unabhängig vom Inhalt
+  von `settings` immer gewinnt. Kein Blocker, da beim einzigen aktuellen
+  Aufrufer nicht ausnutzbar, aber günstige Absicherung für künftige Aufrufer
+  dieser exportierten API-Funktion.
+
+## Könnte (optional, Verbesserung)
+
+- **[Stil]** `frontend/src/api/settings.ts:49-55`: Der ausführliche
+  Inline-Kommentar dupliziert einen Teil der Root-Cause-Erklärung aus
+  `design.md`. Das ist hier bewusst und sinnvoll (siehe Lob unten), langfristig
+  bei Änderungen an der Backend-Logik aber ein zweiter Ort, der synchron
+  gehalten werden muss. Keine Handlung nötig, nur zur Kenntnis.
+- **[Info, kein Handlungsbedarf in diesem Change]** `frontend/src/api/settings.ts:56-59`:
+  Der `Content-Type: multipart/form-data`-Header wird manuell ohne
+  `boundary`-Parameter gesetzt. Das ist unverändert aus dem Vorzustand
+  übernommen (identisches Muster bereits in
+  `frontend/src/api/trainingAttachments.ts:54-58`, dort laut `proposal.md`
+  bereits produktiv funktionierend) und nicht Teil dieses Diffs — daher kein
+  Befund für T01, nur als Kontext für den Fall künftiger Multipart-Probleme.
+
+## Lob (kurz, was gut gelöst wurde)
+
+- Der Fix ist minimal-invasiv und beschränkt sich exakt auf die zwei in
+  `tasks.md`/`design.md` beschriebenen Änderungen (Methode + `_method`-Feld),
+  ohne unnötige Refaktorierung oder globale Interceptor-Logik in `client.ts`
+  — KISS/YAGNI sauber eingehalten.
+- Der Inline-Kommentar (`frontend/src/api/settings.ts:49-55`) macht den
+  Zusammenhang (Root Cause + Method-Override-Mechanismus) direkt im Code
+  nachvollziehbar, ohne dass man `design.md` konsultieren muss.
+- Testabdeckung (`frontend/src/api/settings.test.ts`) deckt alle
+  Akzeptanzkriterien aus `tasks.md` 1:1 ab: Methode, Endpunkt+Header,
+  `_method`-Feld, Text-Feld, File-Feld, Skip von `null`/`undefined`.
+- Backend (`backend/routes/api.php:195`, `SettingsController`,
+  `UpdateSettingsRequest`) wurde korrekt unangetastet gelassen — bestätigt:
+  `Route::put('/settings', [SettingsController::class, 'update'])` bleibt
+  innerhalb der `can:admin`-Middleware-Gruppe unverändert und ist mit dem
+  Method-Override-Ansatz kompatibel, da Laravel
+  `enableHttpMethodParameterOverride()` vor dem Routing anwendet (bestätigt
+  bereits in `verification.md`).
+- Keine PHP-Datei im Diff → Abschnitt 4.1/4.2 CLAUDE.md (PHP-8.3/8.4-Verbote,
+  SQL-Portabilität) nicht betroffen, nichts zu prüfen.

--- a/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/task-T01.test-report.md
+++ b/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/task-T01.test-report.md
@@ -1,0 +1,151 @@
+# Test-Report: T01
+
+**Status:** alle-gruen
+
+## Hinweis zur Test-Konvention
+
+`TESTING.md` im Projekt-Root ist ausschließlich für Backend (Pest/PHPUnit,
+`tests/Feature/`, `tests/Unit/`) verbindlich formuliert (Datei-Header,
+Factory-States, `RefreshDatabase`, Groups-Schema `api`/`feature`/`pdf`/`domain`/
+`unit`) — sie enthält keine Vitest-/Frontend-Konventionen. Für
+`frontend/src/api/settings.test.ts` wurde daher das im Frontend bereits
+etablierte Muster aus `frontend/src/views/CourseDetailView.test.ts` und
+`frontend/src/composables/usePricingItems.test.ts` übernommen: `describe`/`it`
+aus Vitest, englische Testbeschreibungen, `vi.mock('@/api/client', ...)` mit
+Default-Export-Objekt aus `vi.fn()`, Non-null-Assertion (`!`) beim Zugriff auf
+`mock.calls[0]` (wegen `noUncheckedIndexedAccess: true` in `@vue/tsconfig`,
+gleiches Muster wie `usePricingItems.test.ts:155`).
+
+## Hinzugefügte / geänderte Tests
+
+- `frontend/src/api/settings.test.ts`: bestehende 6 Tests des Entwicklers
+  unverändert übernommen, **4 zusätzliche Fälle ergänzt** (jetzt 10 Tests
+  insgesamt):
+  1. `it('still sends only the _method field when called with an empty settings object', …)`
+     — Grenzfall leeres Argument: keine Text-/Datei-Felder außer `_method`.
+  2. `it('carries multiple File values (logo and favicon) into the FormData at once', …)`
+     — Logo **und** Favicon gleichzeitig, da genau das der ursprüngliche
+     Bug-Report war (beide Uploads gingen zusammen verloren).
+  3. `it('coerces non-string primitive values (number, boolean) to strings in the FormData', …)`
+     — deckt den `String(value)`-Zweig für Nicht-String-Primitives ab
+     (bisher nur mit einem String-Wert getestet).
+  4. `it('resolves with the response data returned by apiClient.post', …)`
+     — prüft, dass `updateSettings()` den `response.data` des Mocks
+     tatsächlich zurückgibt (Rückgabewert war bisher ungetestet).
+
+Keine bestehenden Tests wurden verändert, gelöscht oder als `skip`/`xit`
+markiert. Kein Produktivcode wurde angefasst
+(`git diff --stat frontend/src/api/settings.ts` zeigt ausschließlich den
+bereits vom Entwickler committeten Diff aus T01, siehe `task-T01.notes.md`).
+
+## Akzeptanzkriterien-Abdeckung (aus `tasks.md`)
+
+- [x] `formData.append('_method', 'PUT')` wird vor dem Absenden gesetzt —
+      getestet in `settings.test.ts::appends a _method=PUT field to the
+      FormData for method override` und zusätzlich indirekt in
+      `…still sends only the _method field when called with an empty
+      settings object`.
+- [x] Der Request wird über `apiClient.post(...)` gesendet, nicht mehr über
+      `apiClient.put(...)` — getestet in `settings.test.ts::sends the
+      request via apiClient.post, not apiClient.put`.
+- [x] Der Endpunkt bleibt `/api/v1/settings` — getestet in
+      `settings.test.ts::posts to the /api/v1/settings endpoint with
+      multipart headers`.
+- [x] Der Header `Content-Type: multipart/form-data` bleibt erhalten —
+      selber Test wie oben.
+- [x] Datei-Felder (`instanceof File`) und Text-Felder werden weiterhin
+      korrekt ins `FormData` übernommen — getestet in `…carries text fields
+      into the FormData unchanged`, `…carries a File value into the FormData
+      unchanged` sowie neu `…carries multiple File values (logo and
+      favicon) into the FormData at once` (deckt den im Bug-Report konkret
+      genannten Fall Logo+Favicon gleichzeitig ab, was die 6
+      Original-Tests einzeln nicht abdeckten).
+- [x] Vitest-Test `apiClient.post` statt `apiClient.put` mit Pfad
+      `/api/v1/settings` — s. o.
+- [x] Vitest-Test `_method=PUT` im `FormData` via `formData.get('_method')`
+      — s. o.
+- [x] Vitest-Test: `File`-Wert landet unverändert im `FormData` — s. o.
+- [~] `npm run lint` läuft ohne Fehler — **nicht ausführbar**, da
+      `frontend/package.json` kein `lint`-Script enthält und keine
+      ESLint-Konfiguration im `frontend/`-Verzeichnis existiert (bestätigt
+      per `grep -i lint frontend/package.json` → kein Treffer). Bestehender
+      Projektzustand, nicht Teil des Scopes von T01, wird hier nur erneut
+      bestätigt, nicht behoben (keine Produktivcode-/Konfig-Änderung durch
+      den Tester zulässig).
+- [x] `npm run test` läuft ohne Fehler — 121 von 121 Tests grün (11 Dateien),
+      inkl. der 10 Tests in `settings.test.ts`.
+- [x] `npm run build` läuft ohne Warnings oder Fehler — `vue-tsc -b && vite
+      build` durchläuft sauber, 0 TypeScript-Fehler, keine Build-Warnings
+      (Output vollständig unten).
+
+## Ausführungs-Ergebnis
+
+```
+$ npx vitest run src/api/settings.test.ts
+ RUN  v4.1.6 /Users/.../frontend
+ Test Files  1 passed (1)
+      Tests  10 passed (10)
+
+$ npx vitest run
+ RUN  v4.1.6 /Users/.../frontend
+ Test Files  11 passed (11)
+      Tests  121 passed (121)
+
+$ npm run build
+> vue-tsc -b && vite build
+vite v7.3.3 building client environment for production...
+✓ 636 modules transformed.
+...
+dist/assets/SettingsView-lQYjI3bQ.js   40.17 kB │ gzip: 10.09 kB
+...
+✓ built in 1.27s
+(0 Fehler, 0 Warnings)
+
+$ grep -i lint frontend/package.json
+(kein Treffer — bestätigt: kein lint-Script vorhanden)
+
+$ docker compose exec php php artisan test --filter=SettingsValidationTest
+ PASS  Tests\Feature\Api\SettingsValidationTest
+ ✓ it akzeptiert eine ico-datei als company_favicon
+ ✓ it akzeptiert eine ico-datei mit mime-typ image/vnd.microsoft.icon...
+ ✓ it akzeptiert eine png-datei als company_favicon
+ ✓ it weist eine exe-datei als company_favicon zurück
+ ✓ it weist eine datei über 512 kb als company_favicon zurück
+ ✓ it verursacht keinen validierungsfehler wenn company_favicon nicht...
+ ✓ it akzeptiert weiterhin eine png-datei als company_logo
+ Tests: 7 passed (11 assertions)
+```
+
+## Kritische Bewertung der ursprünglichen Testabdeckung
+
+Die 6 vom Entwickler geschriebenen Tests deckten alle expliziten
+Akzeptanzkriterien aus `tasks.md` bereits korrekt ab. Lücken, die für einen
+Bugfix zu verschwindenden Datei-Uploads dennoch sinnvoll zu schließen waren:
+
+1. **Logo + Favicon gleichzeitig** — der ursprüngliche Bug-Report betraf
+   genau diesen Fall (zwei Dateifelder in einem Request). Der Einzeltest mit
+   nur einer Datei hätte eine Regression, die nur bei mehreren
+   `formData.append()`-Aufrufen mit `File`-Werten auftritt (z. B. eine
+   fehlerhafte künftige Refaktorierung, die nur das letzte Datei-Feld
+   verarbeitet), nicht zuverlässig aufgedeckt.
+2. **Leeres Argument** — Grenzwert "leer" gemäß Testpyramiden-Vorgabe im
+   Rollenprofil (leer/eins/viele/ungültig). Stellt sicher, dass `_method`
+   auch ohne weitere Felder gesetzt wird und keine unerwarteten Felder
+   entstehen.
+3. **Nicht-String-Primitives** (`number`, `boolean`) — der `else`-Zweig mit
+   `String(value)` war bisher nur implizit, nie mit einem tatsächlichen
+   Nicht-String-Wert getestet worden.
+4. **Rückgabewert von `updateSettings()`** — bisher wurde nur der
+   *ausgehende* Request geprüft, nie, dass die Funktion den
+   `response.data` des Mocks tatsächlich zurückgibt. Das ist zwar durch die
+   Task nicht explizit gefordert, aber ein naheliegender Vertragsbestandteil
+   der Funktion und günstig gegen zukünftige Refaktorierungen abzusichern.
+
+Alle vier Ergänzungen folgen 1:1 dem Stil der bestehenden Datei (Aufbau,
+Mock-Muster, Non-null-Assertion für `mock.calls[0]!`, `expect()`-Matcher aus
+Vitest). Keine bestehenden Tests wurden dafür verändert.
+
+## Fehler (falls vorhanden)
+
+Keine. Alle 121 Frontend-Tests, der Build sowie der geprüfte Backend-Test
+(`SettingsValidationTest`) sind grün. Kein Fehlschlag zu berichten.

--- a/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/tasks.md
+++ b/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/tasks.md
@@ -1,0 +1,61 @@
+# Tasks: fix-settings-upload-put-multipart
+
+## T01: Transportmethode für Settings-Update auf POST + Method-Override umstellen
+
+- **Agent:** dev-javascript
+- **Dateien:**
+  - `frontend/src/api/settings.ts` (ändern, Zeilen 35-54)
+  - `frontend/src/api/settings.test.ts` (neu erstellen)
+- **Abhängigkeiten:** keine
+- **Beschreibung:**
+  In `settingsApi.updateSettings()` wird:
+  1. Vor dem Befüllen der Datei-/Text-Felder ein zusätzliches
+     `FormData`-Feld `_method` mit Wert `'PUT'` angehängt
+     (`formData.append('_method', 'PUT')`).
+  2. Der Request von `apiClient.put<SettingsResponse>(...)` auf
+     `apiClient.post<SettingsResponse>(...)` umgestellt. Der Endpunkt-Pfad
+     (`/api/v1/settings`) und der `Content-Type`-Header
+     (`multipart/form-data`) bleiben unverändert.
+
+  Details, Vorher/Nachher-Codeblock und Begründung siehe `design.md`,
+  Abschnitt "Lösungsansatz: POST + Method-Override statt echtem PUT".
+
+  Anschließend wird eine neue Vitest-Datei
+  `frontend/src/api/settings.test.ts` erstellt, die `@/api/client` mockt
+  (Muster: `frontend/src/views/CourseDetailView.test.ts:16-30`) und prüft,
+  dass `settingsApi.updateSettings()` tatsächlich `apiClient.post`
+  aufruft (nicht `apiClient.put`) und das `_method=PUT`-Feld im `FormData`
+  enthalten ist.
+
+- **Akzeptanzkriterien:**
+  - [x] `formData.append('_method', 'PUT')` wird vor dem Absenden gesetzt.
+  - [x] Der Request wird über `apiClient.post(...)` gesendet, nicht mehr
+        über `apiClient.put(...)`.
+  - [x] Der Endpunkt bleibt `/api/v1/settings`.
+  - [x] Der Header `Content-Type: multipart/form-data` bleibt erhalten.
+  - [x] Datei-Felder (`instanceof File`) und Text-Felder werden weiterhin
+        korrekt ins `FormData` übernommen (kein Verhaltensunterschied zur
+        bisherigen Logik außer Methode + `_method`-Feld).
+  - [x] Vitest-Test: `settingsApi.updateSettings({ company_name: 'Test' })`
+        ruft `apiClient.post` (nicht `apiClient.put`) mit dem Pfad
+        `/api/v1/settings` auf.
+  - [x] Vitest-Test: Das an `apiClient.post` übergebene `FormData`-Objekt
+        enthält ein Feld `_method` mit Wert `'PUT'`
+        (Prüfung z. B. via `formData.get('_method')` auf dem im Mock
+        empfangenen Argument).
+  - [x] Vitest-Test: Ein `File`-Wert im Argument von `updateSettings()`
+        landet unverändert als Datei-Eintrag im `FormData`.
+  - [~] `npm run lint` läuft ohne Fehler. (Kein `lint`-Script in
+        `frontend/package.json` vorhanden — siehe `task-T01.notes.md`.)
+  - [x] `npm run test` läuft ohne Fehler.
+  - [x] `npm run build` läuft ohne Warnings oder Fehler.
+
+---
+
+## Hinweis für Reviewer (kein separater Task, siehe `design.md`)
+
+Der Reviewer soll bestätigen, dass `backend/routes/api.php:195`
+(`Route::put('/settings', [SettingsController::class, 'update'])`)
+unverändert bleibt und mit dem Method-Override-Ansatz kompatibel ist
+(Laravel wendet `enableHttpMethodParameterOverride()` vor dem Routing an,
+siehe `design.md`). Keine Backend-Datei wird in diesem Change angefasst.

--- a/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/verification.md
+++ b/openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/verification.md
@@ -1,0 +1,184 @@
+# Verification: fix-settings-upload-put-multipart
+
+**Gesamtstatus:** ok
+
+## Schritt 0: Strukturelle Validierung
+
+```
+$ openspec validate fix-settings-upload-put-multipart
+Change 'fix-settings-upload-put-multipart' is valid
+```
+
+Strukturell einwandfrei. Inhaltlicher Realitätsabgleich folgt.
+
+---
+
+## Bestätigt
+
+- `proposal.md` Z.12/`design.md` Z.14: "`frontend/src/api/settings.ts:35-54`,
+  `settingsApi.updateSettings()`" → bestätigt, Funktion beginnt exakt bei
+  Zeile 35 (`async updateSettings(...)`) und endet bei Zeile 54 (`},`) in
+  `frontend/src/api/settings.ts`.
+- `design.md` Z.29 / proposal.md Z.15: "`apiClient.put('/api/v1/settings',
+  formData, …)`, Zeile 48" → bestätigt exakt in
+  `frontend/src/api/settings.ts:48`: `apiClient.put<SettingsResponse>('/api/v1/settings', formData, {`.
+- `design.md` Z.30: `headers: { 'Content-Type': 'multipart/form-data' }` →
+  bestätigt in `frontend/src/api/settings.ts:49-51`.
+- `proposal.md` Z.27 / `design.md` Z.177-178: "Route `PUT /api/v1/settings`
+  (`backend/routes/api.php:195`)" → bestätigt wortwörtlich:
+  `backend/routes/api.php:195`: `Route::put('/settings', [SettingsController::class, 'update']);`
+  (innerhalb einer `prefix('settings')`- bzw. Admin-Middleware-Gruppe ab Z.192-194).
+- `design.md` Z.50 / proposal.md Z.20-21: "`SettingsController::update()`,
+  `backend/app/Http/Controllers/SettingsController.php:37-79`" → bestätigt:
+  Methode beginnt Z.37 (`public function update(UpdateSettingsRequest $request): JsonResponse`)
+  und endet Z.79 (schließende Klammer vor Leerzeile).
+- `design.md` Z.51: "`$request->hasFile($key)` (Zeile 45)" → bestätigt in
+  `backend/app/Http/Controllers/SettingsController.php:45`.
+- `design.md` Z.46 / proposal.md Z.22: "`UpdateSettingsRequest::rules()`
+  (`backend/app/Http/Requests/UpdateSettingsRequest.php:32-59`)" →
+  bestätigt: `rules()`-Array beginnt Z.32 (`return [`) und endet Z.59 (`];`).
+- `design.md` Z.44/47: alle Felder in `rules()` beginnen mit `sometimes`
+  bzw. `sometimes, nullable` → bestätigt für alle 20 Felder in
+  `UpdateSettingsRequest.php:34-58` (inkl. `company_logo` Z.45 und
+  `company_favicon` Z.46, beide `sometimes, nullable`).
+- `design.md` Z.24-25 / proposal.md Z.24-25: "`$request->enableHttpMethodParameterOverride()`,
+  `backend/vendor/laravel/framework/.../Kernel.php:143`" → bestätigt exakt:
+  `backend/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:143`
+  innerhalb `handle()` (beginnt Z.138).
+- Laravel-Version: `backend/composer.lock` meldet `laravel/framework`
+  `v11.51.0`. Für Laravel 11 gibt es standardmäßig **kein**
+  `app/Http/Kernel.php` mehr (bestätigt: `ls backend/app/Http/` enthält
+  keine `Kernel.php`), stattdessen `backend/bootstrap/app.php`
+  (`Application::configure(...)->withMiddleware(...)`). Geprüft, ob die
+  `Illuminate\Foundation\Http\Kernel`-Klasse trotzdem verbindlich gebunden
+  ist: `backend/vendor laravel/framework/.../Configuration/ApplicationBuilder.php:61`
+  bindet `Illuminate\Contracts\Http\Kernel::class` an die Default-Klasse.
+  `backend/bootstrap/app.php` überschreibt diese Bindung nicht (kein
+  eigener Kernel referenziert). Der Method-Override-Aufruf in
+  `Kernel::handle()` ist also tatsächlich aktiv — die Behauptung ist auch
+  unter Laravel 11 korrekt, nicht nur "prinzipiell aus dem Framework-Gedächtnis".
+- `design.md` Z.39-42 / Symfony-Body-Parsing-Behauptung: "`Request::createFromGlobals()`
+  (`backend/vendor/symfony/http-foundation/Request.php:286-312`)... erst ab
+  `PHP_VERSION_ID >= 80400` wird der Body generisch über `request_parse_body()`
+  geparst" → bestätigt exakt: Methode beginnt Z.286, endet Z.312;
+  Z.288 prüft `in_array($_SERVER['REQUEST_METHOD'], ['PUT','DELETE','PATCH','QUERY'])`,
+  Z.292 `if (\PHP_VERSION_ID < 80400)`, Z.305 `request_parse_body()`. Für
+  PHP < 8.4 und PUT wird bei Z.298 `$post = $_POST` übernommen (für PUT vom
+  PHP-SAPI nicht befüllt) und bei Z.301 `$_FILES` direkt durchgereicht (für
+  PUT ebenfalls von PHP nicht befüllt) — bestätigt exakt den behaupteten
+  Mechanismus des Datenverlusts.
+- `design.md` Z.159-160: Vorgeschlagener Fix-Code (POST statt PUT,
+  `formData.append('_method', 'PUT')`) ist syntaktisch konsistent mit dem
+  Ist-Zustand in `frontend/src/api/settings.ts` und verändert nur die
+  behaupteten zwei Stellen (Methode + ein neues Feld).
+- proposal.md Z.110-111 / "Nicht im Scope": "Keine Änderung an
+  `frontend/src/api/trainingAttachments.ts` (verwendet bereits korrekt
+  `POST`, ist nicht betroffen)" → bestätigt:
+  `frontend/src/api/trainingAttachments.ts:54`:
+  `const response = await apiClient.post('/api/v1/training-attachments', formData, {`.
+  Kein `put`/`patch` mit FormData in dieser Datei.
+- proposal.md Z.70-93 / `install.php`/`requirements-check.php`-Widerspruch:
+  - `backend/requirements-check.php:58-60` → bestätigt exakt:
+    `if ($major < 8 || ($major == 8 && $minor < 4)) { ... 'PHP 8.4.0 or higher is required'`.
+  - `backend/requirements-check.php:1-19` Kopfkommentar "Upload this file...
+    DELETE THIS FILE after successful installation" → bestätigt (Z.6, Z.10).
+  - `install.php:851-863` (`checkServerRequirements()`) → bestätigt:
+    Funktion beginnt Z.851, `'required' => '8.2'` und
+    `version_compare(PHP_VERSION, '8.2.0', '>=')` exakt in Z.855-857.
+  - Behauptung "`$canProceed` wird nicht durch die PHP-Version blockiert,
+    solange `>= 8.2`" → bestätigt: `install.php:894-896` setzt
+    `can_proceed = false` **nur** wenn `php_version.status === 'fail'`
+    (also nur unter PHP 8.2). Bei PHP 8.2/8.3 bleibt `status = 'pass'`
+    und `can_proceed = true` (sofern Extensions vorhanden).
+  - `install.php:786`: `checkServerRequirements()` wird tatsächlich im
+    Installer-Flow aufgerufen (nicht totes Code) → bestätigt.
+- `design.md` Z.60-61: "`docker/php/Dockerfile:1` → `FROM php:8.4-fpm-alpine`"
+  → bestätigt exakt.
+- `design.md` Z.99, proposal.md (implizit): `DEPLOYMENT.md` Zeilen
+  19/105/268/424/447 nennen PHP 8.4 → bestätigt: Z.19 "PHP 8.4+ mit
+  benötigten Extensions", Z.105 "✓ PHP Version (8.4+)", Z.268 "Stellen
+  Sie sicher, dass PHP 8.4+ aktiv ist", Z.424 "✓ PHP Version (8.4.x
+  erforderlich)", Z.447 "**PHP**: 8.4 oder höher".
+- `design.md` Z.99 / `PRODUCTION-SETUP.md:13` → bestätigt: Zeile 13 ist
+  `- **PHP**: 8.4`. `PRODUCTION-SETUP.md:5` nennt zusätzlich
+  `www.leisoft.de` als Ziel-URL (Bezug in `design.md` Z.102-104 auf
+  "`PRODUCTION-SETUP.md:1-15`" ist damit im referenzierten Bereich korrekt).
+- `design.md` Z.230-238: "Pest-Tests in
+  `backend/tests/Feature/Api/SettingsValidationTest.php` verwenden
+  `->putJson(...)` ... durchlaufen nicht `Request::createFromGlobals()`"
+  → bestätigt doppelt: (1) `putJson` kommt in
+  `SettingsValidationTest.php` an mehreren Stellen vor (Z.24, 34, 46, 58,
+  71, 82, 94 u.a.); (2) `MakesHttpRequests::call()`
+  (`backend/vendor/laravel/framework/.../Concerns/MakesHttpRequests.php:596-618`)
+  baut den Request über `SymfonyRequest::create(...)` (Z.602), **nicht**
+  über `createFromGlobals()` — die Behauptung, dass diese Tests die
+  betroffene Bug-Klasse strukturell nicht erkennen können, ist technisch
+  korrekt.
+- proposal.md "Nicht im Scope" / tasks.md T01: Testmuster-Referenz
+  `frontend/src/views/CourseDetailView.test.ts:16-30` → im Wesentlichen
+  bestätigt: Der `vi.mock('@/api/client', ...)`-Block liegt tatsächlich in
+  dieser Datei bei Z.16-22 (nicht exakt bis Z.30 — der Mock-Block für
+  `@/api/client` endet bei Z.22, weitere `vi.mock`-Blöcke für
+  `errorHandler`/`axios` folgen bis Z.34). Kleinere Zeilenungenauigkeit,
+  Kernaussage (Muster existiert, mockt `@/api/client` mit `vi.fn()`) ist
+  korrekt.
+
+## Widerlegt
+
+Keine widerlegten Tatsachenbehauptungen gefunden. Alle konkret mit
+Datei:Zeile belegten Aussagen in `proposal.md` und `design.md` wurden
+gegen den Code geprüft und stimmen.
+
+## Nicht auffindbar
+
+Keine. Alle referenzierten Dateien, Zeilen und Funktionen wurden gefunden.
+
+## Neue Elemente (Plausibilität)
+
+- `tasks.md` T01: legt `frontend/src/api/settings.test.ts` neu an →
+  `frontend/src/api/` existiert bereits (`settings.ts`,
+  `trainingAttachments.ts`, `client.ts` u.a.), keine gleichnamige Datei
+  vorhanden (`find frontend/src/api -iname "settings.test.ts"` → kein
+  Treffer). Pfad ist konsistent mit bestehenden Testdateien im Projekt
+  (z. B. `frontend/src/views/CourseDetailView.test.ts` liegt neben der
+  Quelldatei — gleiches Muster für `frontend/src/api/*.test.ts` wurde
+  nicht gegengeprüft, da im Scope nicht referenziert; Pfadwahl ist aber
+  plausibel und kollisionsfrei).
+
+## Zusätzliche Prüfungen über den Auftrag hinaus (Vollständigkeit)
+
+- **Weitere FormData-Aufrufstellen im Frontend:** `grep -rl "FormData"
+  frontend/src` findet nur drei Dateien:
+  `frontend/src/components/DogFormModal.vue`,
+  `frontend/src/api/settings.ts`, `frontend/src/api/trainingAttachments.ts`.
+  Geprüft, ob `DogFormModal.vue` denselben Bug hat (PUT + FormData): **nein**
+  — `DogFormModal.vue:397` sendet den Hund-Datensatz per
+  `apiClient.put(...)` aber mit einem reinen JSON-`payload`-Objekt (kein
+  FormData); der Bild-Upload erfolgt getrennt per
+  `apiClient.post('/api/v1/dogs/{id}/upload-image', formData, ...)`
+  (`DogFormModal.vue:411`). Es gibt also **keinen zweiten,
+  unentdeckten PUT+Multipart-Fall** im aktuell durchsuchten Frontend-Code
+  — proposal.md/design.md haben den einzigen betroffenen Call-Site
+  korrekt identifiziert (Bestätigung von design.md Z.259-261, YAGNI-Begründung
+  "aktuell gibt es nur einen betroffenen Call-Site").
+- **`settings-favicon-upload`-Capability-Konflikt geprüft:**
+  `openspec/specs/settings-favicon-upload/spec.md` existiert und
+  beschreibt Backend-Validierungsszenarien auf Basis von
+  `PUT /api/v1/settings` (Z.22, 28) — das ist die logische Route und bleibt
+  durch den Method-Override-Fix unverändert, kein Widerspruch zur neuen
+  Spec `settings-file-upload-transport`.
+
+## Empfehlung
+
+Alle konkreten Tatsachenbehauptungen in `proposal.md`, `design.md` und
+`tasks.md` wurden mit Datei:Zeile-Beleg gegengeprüft und treffen exakt zu
+— inklusive der eher ungewöhnlichen, tiefgehenden Behauptungen (Symfony
+`createFromGlobals()`-Verhalten, Laravel-11-Kernel-Bindung ohne
+`app/Http/Kernel.php`, `install.php`/`requirements-check.php`-Widerspruch,
+Test-Client-Limitation von `putJson`). Der Fix-Ansatz (POST +
+`_method=PUT`-Override) ist architektonisch korrekt und durch die
+Laravel-11-Kernel-Bindung tatsächlich aktiv, nicht nur behauptet. Die
+Spec ist verlässlich genug zum Fortfahren — keine Korrekturen am Design
+nötig. Einzige Randnotiz (keine Blocker): Der Testmuster-Verweis auf
+`CourseDetailView.test.ts:16-30` ist um wenige Zeilen ungenau, das ist
+für die Umsetzung irrelevant.

--- a/openspec/specs/settings-file-upload-transport/spec.md
+++ b/openspec/specs/settings-file-upload-transport/spec.md
@@ -1,0 +1,81 @@
+# Spec: settings-file-upload-transport
+
+**Status:** ADDED
+**Capability:** Transportweg für Datei-Uploads beim Speichern der Systemeinstellungen
+
+---
+
+## Purpose
+
+Wenn der Admin Systemeinstellungen speichert, die Dateien enthalten
+(Firmenlogo, Favicon), muss der Request so an das Backend übertragen
+werden, dass PHP den Request-Body inklusive Dateien zuverlässig auswertet
+— unabhängig von der auf dem Server laufenden PHP-Version (8.2, 8.3 oder
+8.4) und unabhängig davon, ob echte HTTP-PUT-Requests mit
+`multipart/form-data`-Body auf dem jeweiligen Server korrekt geparst
+werden. Das Backend muss die Anfrage weiterhin als logisches `PUT`
+behandeln (Autorisierung, Validierung, Idempotenz-Semantik unverändert).
+
+---
+
+## ADDED Requirements
+
+### Requirement: Settings-Update wird als POST mit Method-Override gesendet
+
+Der Frontend-Client SHALL Settings-Update-Requests (`PUT /api/v1/settings`),
+die potenziell Dateien enthalten, als HTTP-`POST` mit einem zusätzlichen
+`FormData`-Feld `_method=PUT` senden, statt ein echtes HTTP-`PUT` mit
+`multipart/form-data`-Body zu verwenden. Damit befüllt PHP `$_POST` und
+`$_FILES` in jeder unterstützten PHP-Version (8.2, 8.3, 8.4) zuverlässig,
+weil `POST` von der SAPI immer nativ geparst wird, unabhängig von
+`request_parse_body()`-Verfügbarkeit oder sonstigen Server-Eigenheiten.
+Das Backend MUSS den Request weiterhin fachlich als `PUT` behandeln
+(Routing, Autorisierung, Validierung unverändert) — Laravels
+Method-Override-Mechanismus übernimmt das vor dem Routing.
+
+#### Scenario: Update ohne Datei
+- **GIVEN** der Admin ändert nur Textfelder (z. B. `company_name`) in den
+  Einstellungen und enthält keine Datei
+- **WHEN** das Formular gespeichert wird
+- **THEN** der Client sendet ein HTTP-`POST` an `/api/v1/settings`
+- **AND** der `FormData`-Body enthält ein Feld `_method` mit dem Wert `PUT`
+- **AND** das Backend behandelt die Anfrage als `PUT` (Autorisierung via
+  `SettingsController::update()` greift wie bisher)
+
+#### Scenario: Update mit Firmenlogo
+- **GIVEN** der Admin wählt eine neue Logo-Datei aus
+- **WHEN** das Formular gespeichert wird
+- **THEN** der Client sendet ein HTTP-`POST` an `/api/v1/settings` mit
+  `Content-Type: multipart/form-data`
+- **AND** der `FormData`-Body enthält sowohl das Feld `_method=PUT` als
+  auch die Logo-Datei unter ihrem Feldnamen (z. B. `company_logo`)
+- **AND** die Datei kommt serverseitig zuverlässig in `$request->hasFile('company_logo')`
+  an — unabhängig von der PHP-Version des Servers
+
+#### Scenario: Update mit Favicon
+- **GIVEN** der Admin wählt eine neue Favicon-Datei aus (PNG oder ICO)
+- **WHEN** das Formular gespeichert wird
+- **THEN** gilt dieselbe Übertragungslogik wie beim Firmenlogo (POST +
+  `_method=PUT` + Datei im `FormData`)
+
+#### Scenario: Server-seitiges Routing bleibt unverändert
+- **GIVEN** ein POST-Request mit `_method=PUT` im `FormData`-Body erreicht
+  das Backend
+- **WHEN** Laravel den Request verarbeitet
+- **THEN** die Route `PUT /api/v1/settings` matcht weiterhin (Method-Override
+  wird vor dem Routing angewendet)
+- **AND** `SettingsController::update()` erhält den Request unverändert wie
+  bei einem echten `PUT`-Request
+
+---
+
+## Nicht Teil dieser Spec
+
+- Validierungsregeln für einzelne Settings-Felder (siehe Capability
+  `settings-favicon-upload` für die MIME-/Größenregeln von
+  `company_favicon`).
+- Verhalten des Frontend-Formulars bei Speicherfehlern (siehe ebenfalls
+  `settings-favicon-upload`).
+- Serverseitige PHP-Versionsanforderungen für Deployment/Installer — das
+  ist Gegenstand der offenen Punkte in `proposal.md` dieses Changes und
+  potenziell eines eigenen, künftigen Changes.

--- a/openspec/triage/20260701195331-settings-upload-put-multipart-lost.md
+++ b/openspec/triage/20260701195331-settings-upload-put-multipart-lost.md
@@ -1,0 +1,101 @@
+# Triage: Firmenlogo/Favicon-Upload verschwindet nach Speichern (PUT + multipart)
+
+**Pfad:** klein
+**Geschätzter Umfang:** ~1-2 Kern-Dateien (Frontend), Sprachen: JavaScript/TypeScript (Vue), keine PHP-Änderung zwingend nötig
+**Risiko:** mittel — betrifft Firmen-Branding (Logo/Favicon auf Rechnungen/E-Mails), Datenverlust ist still (kein Fehler wird angezeigt), Bug ist PHP-Versions-abhängig und trifft genau die in CLAUDE.md Abschnitt 3 als kritisch markierte Demo-Umgebung (PHP 8.2/8.3).
+**Klarheit:** klar — der gemeldete Effekt (Dateien "verschwinden" ohne Fehlermeldung nach Speichern) ist eindeutig, und die Ursache konnte im Code zweifelsfrei nachvollzogen werden.
+
+## Anforderung (Zusammenfassung)
+
+Der Admin lädt Firmenlogo und Favicon in den Einstellungen hoch, drückt
+Speichern — die Dateien werden augenscheinlich nicht gespeichert
+("verschwinden"). Es soll geklärt werden, ob dies eine Regression/Fortsetzung
+des kürzlich gemergten Fixes (PR #64, Commit d80d7ec, Change
+`fix-favicon-ico-upload-bug`) ist oder ein neues, eigenständiges Problem.
+
+## Untersuchung / Befund
+
+**Betroffene Stellen:**
+- `frontend/src/api/settings.ts:35-54` (`settingsApi.updateSettings`) — sendet
+  `FormData` (inkl. Files) via `apiClient.put(...)`, also als echtes HTTP-PUT
+  mit `Content-Type: multipart/form-data`.
+- `frontend/src/api/client.ts` — kein Interceptor für Method-Override
+  vorhanden.
+- `backend/routes/api.php:195` — `Route::put('/settings', [SettingsController::class, 'update'])`.
+- `backend/app/Http/Controllers/SettingsController.php` — verarbeitet
+  `$request->hasFile($key)` korrekt, sofern die Datei überhaupt im Request
+  ankommt.
+- `backend/vendor/symfony/http-foundation/Request.php:286-312`
+  (`createFromGlobals`) — **Kernbefund:** Für die Methoden `PUT`/`PATCH`/`DELETE`
+  parst Symfony den Body nur bei `PHP_VERSION_ID >= 80400` generisch via
+  die neue PHP-8.4-Funktion `request_parse_body()` (inkl. Multipart/Dateien).
+  Auf **PHP < 8.4** wird der Body für `multipart/form-data` **gar nicht**
+  geparst (`$post = $_POST` bzw. `$_FILES`, die von PHP selbst nur bei
+  Methode `POST` befüllt werden) — Felder und Dateien gehen also komplett
+  verloren, ohne dass eine Validierungsfehlermeldung entsteht (alle Felder
+  in `UpdateSettingsRequest` sind `sometimes`/`nullable`).
+- **Projektrelevanz:** Laut CLAUDE.md Abschnitt 3 läuft die Demo-Umgebung
+  auf **PHP 8.2/8.3** (Produktion und lokales Docker auf 8.4,
+  `docker/php/Dockerfile:1` → `php:8.4-fpm-alpine`). Die lokale Host-PHP-CLI
+  in dieser Umgebung meldet `PHP 8.3.30` — d.h. der Bug ist auf genau den
+  Umgebungen reproduzierbar, die CLAUDE.md als kritischen kleinsten
+  gemeinsamen Nenner definiert.
+- **Warum die bestehenden Tests den Bug nicht fangen:** Die in PR #64
+  hinzugefügten Tests (`backend/tests/Feature/Api/SettingsValidationTest.php`)
+  nutzen Laravels `->putJson(...)`-Test-Helper. Dieser baut das
+  `Illuminate\Http\Request`-Objekt direkt im Prozess auf und durchläuft
+  **nicht** `Request::createFromGlobals()` bzw. die reale PHP-SAPI-
+  Body-Parsung — die Tests sind also grün, unabhängig von der PHP-Version
+  und unabhängig von diesem Bug.
+
+**Abgrenzung zum vorherigen Fix (d80d7ec / `fix-favicon-ico-upload-bug`):**
+Der vorherige Fix behob (a) eine MIME-Type-Ablehnung von `.ico`-Dateien in
+`UpdateSettingsRequest` und (b) einen UI-Bug, bei dem ein 422-Speicherfehler
+das gesamte Formular ausblendete. Der jetzt gemeldete Effekt zeigt **keine**
+Fehlermeldung — die Dateien verschwinden kommentarlos. Das ist konsistent
+mit der neuen Ursache (Request-Body kommt gar nicht erst mit Dateien beim
+Server an) und **nicht** mit dem vorherigen Bug. **Einschätzung: neues,
+eigenständiges Problem**, keine Regression des d80d7ec-Fixes — beide Bugs
+betreffen zufällig denselben Feature-Bereich (Settings-Datei-Upload), haben
+aber unterschiedliche Root Causes.
+
+**Weitere Prüfung:** `frontend/src/api/trainingAttachments.ts` verwendet für
+Datei-Uploads korrekt `apiClient.post(...)` — dort besteht das Problem nicht.
+Es ist aktuell der einzige weitere FormData-Uploadpfad im Frontend.
+
+## Rückfragen an den User
+
+_(Klarheit = klar, daher keine zwingenden Rückfragen. Optional zur
+Priorisierung:)_
+- Wurde der Bug auf der Demo-Umgebung (Shared Hosting, PHP 8.2/8.3)
+  beobachtet, oder auch lokal/produktiv (PHP 8.4)? Das würde die Diagnose
+  zusätzlich bestätigen, ist aber für den Fix nicht blockierend.
+
+## Empfohlene nächste Aktion
+
+`@architect` (Modus A) soll einen kleinen Change (`fix-settings-upload-put-multipart`)
+aufsetzen mit voraussichtlich folgenden Tasks:
+
+1. **dev-javascript:** `frontend/src/api/settings.ts` — `updateSettings()`
+   so ändern, dass statt eines echten HTTP-PUT mit Multipart-Body ein
+   POST mit Laravel-Method-Override (`_method=PUT` als zusätzliches
+   FormData-Feld) gesendet wird. Das ist PHP-versionsunabhängig, da es nicht
+   von `request_parse_body()` (PHP 8.4) abhängt, sondern von Laravels
+   `Request::enableHttpMethodParameterOverride()` (bereits aktiv, siehe
+   `backend/vendor/laravel/framework/.../Http/Kernel.php:143`).
+2. **Test-Strategie (wichtig, an Tester/Architekt weiterzugeben):** Die
+   bestehenden Pest-`putJson`-Tests reichen NICHT aus, um diese Bug-Klasse
+   zu verhindern (siehe Befund oben). Empfehlung: Vitest-Test auf
+   `settingsApi.updateSettings`, der prüft, dass tatsächlich ein POST mit
+   `_method=PUT` gesendet wird; optional ergänzend ein echter
+   HTTP-Ebenen-Test (z. B. Playwright E2E gegen den echten PHP-Server) statt
+   nur Laravels In-Prozess-Test-Client.
+3. Kein Backend-Code zwingend nötig (Controller verarbeitet `hasFile()`
+   bereits korrekt), aber Reviewer soll bestätigen, dass die PUT-Route in
+   `backend/routes/api.php:195` mit method-override kompatibel bleibt
+   (ist sie, da Laravel das Override vor dem Routing anwendet).
+
+Kein Skeptiker-Overkill nötig aufgrund der geringen Dateizahl, aber wegen
+der PHP-Versions-Kritikalität sollte der Architekt im `design.md` explizit
+vermerken, dass die Lösung auf PHP 8.2, 8.3 und 8.4 identisch funktionieren
+muss (CLAUDE.md Abschnitt 3/9.5).


### PR DESCRIPTION
## Summary
- Settings-Update sendete Firmenlogo/Favicon per echtem HTTP-PUT mit `multipart/form-data`-Body; PHP befüllt `$_POST`/`$_FILES` aber nativ nur bei POST, wodurch die Dateien beim Speichern kommentarlos verloren gingen (kein Fehler, da alle Settings-Felder `sometimes`/`nullable` sind).
- Fix: `settingsApi.updateSettings()` sendet jetzt POST mit Laravels Method-Override (`_method=PUT` im FormData) statt echtem PUT. Route/Controller bleiben unverändert, da Laravel das Override vor dem Routing anwendet.
- Kein Backend-Code geändert.

## Workflow
Durchlaufen via triage → architect (proposal/design/tasks) → skeptic (Codeprüfung, alle Annahmen bestätigt) → dev-javascript (Implementierung + Tests) → reviewer + tester (parallel) → architect (Abnahme) → archiviert unter `openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/`.

## Test plan
- [x] `npx vitest run src/api/settings.test.ts` — 10/10 grün (deckt POST statt PUT, `_method=PUT`-Feld, Text-/Datei-Felder, Logo+Favicon gleichzeitig, Edge Cases)
- [x] `npm run test -- --run` — 121/121 grün (Gesamt-Frontend-Suite)
- [x] `npm run build` — keine Fehler/Warnungen
- [x] Backend `SettingsValidationTest` weiterhin grün (unbeeinflusst, kein Backend-Code geändert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)