### PR TITLE
Optionalen Ankündigungsbereich auf der Landingpage ergänzen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: frontend/package.json
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Install npm dependencies
         working-directory: frontend

--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,6 @@ frontend/dist/
 # Keep production htaccess template
 !frontend/dist/.htaccess
 
-# Package locks (keep composer.lock, remove package-lock if using yarn)
-package-lock.json
-
 # HomoCanis Webseite
 HomoCanis
 

--- a/backend/app/Http/Controllers/Api/AnnouncementController.php
+++ b/backend/app/Http/Controllers/Api/AnnouncementController.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreAnnouncementRequest;
+use App\Http\Requests\UpdateAnnouncementRequest;
+use App\Http\Resources\AnnouncementResource;
+use App\Models\Announcement;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+/**
+ * Announcement Controller
+ *
+ * Handles CRUD operations for announcements. The public endpoint exposes
+ * only currently active announcements, while all admin endpoints require
+ * an admin user and expose the full history (active and expired).
+ */
+class AnnouncementController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Display a listing of currently active announcements.
+     *
+     * Unauthenticated/public endpoint, used by the landing page banner.
+     */
+    public function publicIndex(): AnonymousResourceCollection
+    {
+        $announcements = Announcement::query()
+            ->active()
+            ->orderByDesc('created_at')
+            ->get();
+
+        return AnnouncementResource::collection($announcements);
+    }
+
+    /**
+     * Display a listing of all announcements, including expired ones.
+     *
+     * Admin-only endpoint used by the announcement management area.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        $this->authorize('viewAny', Announcement::class);
+
+        return AnnouncementResource::collection(
+            Announcement::query()->orderByDesc('created_at')->get()
+        );
+    }
+
+    /**
+     * Store a newly created announcement.
+     *
+     * Authorization is enforced by StoreAnnouncementRequest::authorize().
+     */
+    public function store(StoreAnnouncementRequest $request): JsonResponse
+    {
+        $data = $request->validatedSnakeCase();
+
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $this->storeImage($request);
+        }
+
+        $announcement = Announcement::create($data);
+
+        return (new AnnouncementResource($announcement))->response()->setStatusCode(201);
+    }
+
+    /**
+     * Update the specified announcement.
+     *
+     * Replaces the stored image (deleting the previous one from disk) when
+     * a new image is uploaded.
+     */
+    public function update(UpdateAnnouncementRequest $request, Announcement $announcement): AnnouncementResource
+    {
+        $this->authorize('update', $announcement);
+
+        $data = $request->validatedSnakeCase();
+
+        if ($request->hasFile('image')) {
+            $this->deleteImageIfExists($announcement);
+            $data['image_path'] = $this->storeImage($request);
+        }
+
+        $announcement->update($data);
+
+        return new AnnouncementResource($announcement->fresh());
+    }
+
+    /**
+     * Remove the specified announcement and its associated image from disk.
+     */
+    public function destroy(Announcement $announcement): JsonResponse
+    {
+        $this->authorize('delete', $announcement);
+
+        $this->deleteImageIfExists($announcement);
+
+        $announcement->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Store the uploaded image on the public disk and return its path.
+     */
+    private function storeImage(Request $request): string
+    {
+        $file = $request->file('image');
+        $extension = strtolower($file->getClientOriginalExtension());
+        $filename = 'announcement_'.Str::uuid().'.'.$extension;
+
+        return $file->storeAs('announcement-images', $filename, 'public');
+    }
+
+    /**
+     * Delete the announcement's current image from the public disk, if any.
+     */
+    private function deleteImageIfExists(Announcement $announcement): void
+    {
+        if ($announcement->image_path && Storage::disk('public')->exists($announcement->image_path)) {
+            Storage::disk('public')->delete($announcement->image_path);
+        }
+    }
+}

--- a/backend/app/Http/Requests/StoreAnnouncementRequest.php
+++ b/backend/app/Http/Requests/StoreAnnouncementRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Http\Requests\Concerns\SanitizesHtmlContent;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Store Announcement Request
+ *
+ * Validates incoming requests to create a new announcement.
+ */
+class StoreAnnouncementRequest extends FormRequest
+{
+    use SanitizesHtmlContent;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // Only admins can create announcements
+        return $this->user()?->isAdmin() ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'body' => ['required', 'string', 'max:5000'],
+            'displayDays' => ['required', 'integer', 'min:1', 'max:365'],
+            'image' => ['nullable', 'image', 'mimes:jpg,jpeg,png,gif,webp', 'max:5120'],
+        ];
+    }
+
+    /**
+     * Get validated data with snake_case keys for database.
+     *
+     * The image upload is intentionally excluded here — the controller
+     * handles file storage separately and sets image_path itself.
+     *
+     * @return array<string, mixed>
+     */
+    public function validatedSnakeCase(): array
+    {
+        $validated = $this->validated();
+
+        return [
+            'title' => $validated['title'],
+            'body' => $this->sanitizeHtmlDescription($validated['body']),
+            'display_days' => $validated['displayDays'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/UpdateAnnouncementRequest.php
+++ b/backend/app/Http/Requests/UpdateAnnouncementRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Http\Requests\Concerns\SanitizesHtmlContent;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Update Announcement Request
+ *
+ * Validates incoming requests to update an existing announcement.
+ * All fields are optional to allow partial updates.
+ */
+class UpdateAnnouncementRequest extends FormRequest
+{
+    use SanitizesHtmlContent;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // Only admins can update announcements
+        return $this->user()?->isAdmin() ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['sometimes', 'string', 'max:255'],
+            'body' => ['sometimes', 'string', 'max:5000'],
+            'displayDays' => ['sometimes', 'integer', 'min:1', 'max:365'],
+            'image' => ['nullable', 'image', 'mimes:jpg,jpeg,png,gif,webp', 'max:5120'],
+        ];
+    }
+
+    /**
+     * Get validated data with snake_case keys for database.
+     *
+     * Only fields actually present in the request are returned, so
+     * untouched fields are left unchanged by the caller's update() call.
+     * The image upload is intentionally excluded here — the controller
+     * handles file storage separately and sets image_path itself.
+     *
+     * @return array<string, mixed>
+     */
+    public function validatedSnakeCase(): array
+    {
+        $validated = $this->validated();
+        $result = [];
+
+        if (array_key_exists('title', $validated)) {
+            $result['title'] = $validated['title'];
+        }
+
+        if (array_key_exists('body', $validated)) {
+            $result['body'] = $this->sanitizeHtmlDescription($validated['body']);
+        }
+
+        if (array_key_exists('displayDays', $validated)) {
+            $result['display_days'] = $validated['displayDays'];
+        }
+
+        return $result;
+    }
+}

--- a/backend/app/Http/Resources/AnnouncementResource.php
+++ b/backend/app/Http/Resources/AnnouncementResource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Announcement;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Announcement Resource
+ *
+ * Transforms announcement model into a consistent JSON response format.
+ *
+ * @mixin Announcement
+ */
+class AnnouncementResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'body' => $this->body,
+            'imageUrl' => $this->image_path
+                ? Storage::disk('public')->url($this->image_path)
+                : null,
+            'displayDays' => $this->display_days,
+            'expiresAt' => $this->expires_at?->toISOString(),
+            'isActive' => $this->isActive(),
+            'createdAt' => $this->created_at?->toISOString(),
+            'updatedAt' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/backend/app/Models/Announcement.php
+++ b/backend/app/Models/Announcement.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * Announcement Model
+ *
+ * @property int $id
+ * @property string $title
+ * @property string $body
+ * @property string|null $image_path
+ * @property int $display_days
+ * @property Carbon $expires_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+class Announcement extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'title',
+        'body',
+        'image_path',
+        'display_days',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'display_days' => 'integer',
+            'expires_at' => 'datetime',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Recompute expires_at from the original publish date whenever
+     * display_days changes (create, or admin extends/shortens the
+     * display duration on an existing announcement). Uses the existing
+     * created_at as the base on update so editing an announcement does
+     * not silently reset its display window to "now".
+     */
+    protected static function booted(): void
+    {
+        static::saving(function (Announcement $announcement): void {
+            if (! $announcement->exists || $announcement->isDirty('display_days')) {
+                $base = ($announcement->exists && $announcement->created_at)
+                    ? $announcement->created_at
+                    : now();
+
+                $announcement->expires_at = $base->copy()->addDays((int) $announcement->display_days);
+            }
+        });
+    }
+
+    /**
+     * Whether the announcement is currently within its display window.
+     */
+    public function isActive(): bool
+    {
+        return $this->expires_at->isFuture();
+    }
+
+    /**
+     * Scope a query to only include currently active announcements.
+     */
+    public function scopeActive($query)
+    {
+        return $query->where('expires_at', '>', now());
+    }
+}

--- a/backend/app/Policies/AnnouncementPolicy.php
+++ b/backend/app/Policies/AnnouncementPolicy.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Announcement;
+use App\Models\User;
+
+/**
+ * Announcement Policy
+ *
+ * Defines authorization logic for announcement operations. Only admins
+ * may manage announcements.
+ */
+class AnnouncementPolicy
+{
+    /**
+     * Determine whether the user can view any announcements.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can view the announcement.
+     */
+    public function view(User $user, Announcement $announcement): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can create announcements.
+     */
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can update the announcement.
+     */
+    public function update(User $user, Announcement $announcement): bool
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can delete the announcement.
+     */
+    public function delete(User $user, Announcement $announcement): bool
+    {
+        return $user->isAdmin();
+    }
+}

--- a/backend/database/factories/AnnouncementFactory.php
+++ b/backend/database/factories/AnnouncementFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Announcement;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Announcement>
+ */
+class AnnouncementFactory extends Factory
+{
+    protected $model = Announcement::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => fake()->sentence(6),
+            'body' => '<p>'.fake()->paragraph().'</p>',
+            'image_path' => null,
+            'display_days' => fake()->numberBetween(1, 30),
+        ];
+    }
+
+    /**
+     * Indicate that the announcement's display window has already ended.
+     *
+     * Sets created_at/expires_at directly into the past via forceFill() +
+     * saveQuietly(), bypassing the model's "saving" event so the
+     * booted() hook does not recompute expires_at from display_days and
+     * overwrite these deliberately expired testing values.
+     */
+    public function expired(): static
+    {
+        return $this->afterCreating(function (Announcement $announcement) {
+            $announcement->forceFill([
+                'created_at' => now()->subDays(10),
+                'expires_at' => now()->subDays(9),
+            ])->saveQuietly();
+        });
+    }
+}

--- a/backend/database/migrations/2026_07_17_100000_create_announcements_table.php
+++ b/backend/database/migrations/2026_07_17_100000_create_announcements_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('announcements', function (Blueprint $table) {
+            $table->id();
+            $table->string('title', 255);
+            $table->text('body');
+            $table->string('image_path')->nullable();
+            $table->unsignedSmallInteger('display_days');
+            $table->timestamp('expires_at');
+            $table->timestamps();
+
+            $table->index('expires_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('announcements');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\AnamnesisResponseController;
 use App\Http\Controllers\AnamnesisTemplateController;
+use App\Http\Controllers\Api\AnnouncementController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\BookingController;
 use App\Http\Controllers\Api\ContactController;
@@ -54,6 +55,11 @@ Route::prefix('v1')->middleware('throttle:contact')->group(function () {
 // Public pricing route (no auth required)
 Route::prefix('v1')->group(function () {
     Route::get('/pricing-items', [PricingItemController::class, 'publicIndex']);
+});
+
+// Public announcements route (no auth required)
+Route::prefix('v1')->group(function () {
+    Route::get('/announcements', [AnnouncementController::class, 'publicIndex']);
 });
 
 // Public course detail route (no auth required, rate limited)
@@ -193,6 +199,14 @@ Route::prefix('v1')->middleware('auth:sanctum')->group(function () {
     Route::middleware('can:admin')->group(function () {
         Route::get('/settings', [SettingsController::class, 'index']);
         Route::put('/settings', [SettingsController::class, 'update']);
+    });
+
+    // Announcement Management (Admin only)
+    Route::middleware('can:admin')->group(function () {
+        Route::get('/admin/announcements', [AnnouncementController::class, 'index']);
+        Route::post('/admin/announcements', [AnnouncementController::class, 'store']);
+        Route::put('/admin/announcements/{announcement}', [AnnouncementController::class, 'update']);
+        Route::delete('/admin/announcements/{announcement}', [AnnouncementController::class, 'destroy']);
     });
 });
 

--- a/backend/tests/Feature/Api/AnnouncementApiTest.php
+++ b/backend/tests/Feature/Api/AnnouncementApiTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Announcement;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+uses()->group('api', 'announcement');
+
+it('liefert am öffentlichen endpunkt nur aktive ankündigungen', function () {
+    $active = Announcement::factory()->create();
+    $expired = Announcement::factory()->expired()->create();
+
+    $response = $this->getJson('/api/v1/announcements');
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $active->id);
+
+    expect($response->json('data.*.id'))->not->toContain($expired->id);
+});
+
+it('liefert am admin-endpunkt auch abgelaufene ankündigungen', function () {
+    $admin = User::factory()->admin()->create();
+    Announcement::factory()->create();
+    Announcement::factory()->expired()->create();
+
+    $response = $this->actingAs($admin)->getJson('/api/v1/admin/announcements');
+
+    $response->assertOk()
+        ->assertJsonCount(2, 'data');
+});
+
+it('weist die listenanfrage eines nicht-admins am admin-endpunkt mit 403 zurück', function () {
+    $customer = User::factory()->customer()->create();
+
+    $response = $this->actingAs($customer)->getJson('/api/v1/admin/announcements');
+
+    $response->assertForbidden();
+});
+
+it('weist das erstellen einer ankündigung durch einen nicht-admin mit 403 zurück', function () {
+    $customer = User::factory()->customer()->create();
+
+    $response = $this->actingAs($customer)->postJson('/api/v1/admin/announcements', [
+        'title' => 'Neuigkeit',
+        'body' => '<p>Hallo</p>',
+        'displayDays' => 7,
+    ]);
+
+    $response->assertForbidden();
+});
+
+it('weist das aktualisieren einer ankündigung durch einen nicht-admin mit 403 zurück', function () {
+    $customer = User::factory()->customer()->create();
+    $announcement = Announcement::factory()->create();
+
+    $response = $this->actingAs($customer)->putJson(
+        "/api/v1/admin/announcements/{$announcement->id}",
+        ['title' => 'Neuer Titel']
+    );
+
+    $response->assertForbidden();
+});
+
+it('weist das löschen einer ankündigung durch einen nicht-admin mit 403 zurück', function () {
+    $customer = User::factory()->customer()->create();
+    $announcement = Announcement::factory()->create();
+
+    $response = $this->actingAs($customer)->deleteJson("/api/v1/admin/announcements/{$announcement->id}");
+
+    $response->assertForbidden();
+});
+
+it('speichert eine ankündigung mit bild-upload und liefert eine gültige imageUrl', function () {
+    Storage::fake('public');
+    $admin = User::factory()->admin()->create();
+    $file = UploadedFile::fake()->image('banner.jpg');
+
+    $response = $this->actingAs($admin)->postJson('/api/v1/admin/announcements', [
+        'title' => 'Sommerferien',
+        'body' => '<p>Wir haben geschlossen.</p>',
+        'displayDays' => 14,
+        'image' => $file,
+    ]);
+
+    $response->assertCreated();
+
+    $created = Announcement::query()->latest('id')->firstOrFail();
+    expect($created->image_path)->not->toBeNull();
+    Storage::disk('public')->assertExists($created->image_path);
+
+    $expectedUrl = Storage::disk('public')->url($created->image_path);
+    $response->assertJsonPath('data.imageUrl', $expectedUrl);
+});
+
+it('entfernt rohes script- und onclick-html aus dem body-feld beim speichern', function () {
+    $admin = User::factory()->admin()->create();
+
+    $response = $this->actingAs($admin)->postJson('/api/v1/admin/announcements', [
+        'title' => 'Wichtiger Hinweis',
+        'body' => '<p onclick="alert(1)">Hallo</p><script>alert(1)</script>',
+        'displayDays' => 5,
+    ]);
+
+    $response->assertCreated();
+
+    $this->assertDatabaseHas('announcements', [
+        'title' => 'Wichtiger Hinweis',
+        'body' => '<p>Hallo</p>alert(1)',
+    ]);
+});
+
+it('löscht das alte bild von der public-disk wenn beim aktualisieren ein neues bild hochgeladen wird', function () {
+    Storage::fake('public');
+    $admin = User::factory()->admin()->create();
+    $oldFile = UploadedFile::fake()->image('old.jpg');
+    $announcement = Announcement::factory()->create([
+        'image_path' => $oldFile->store('announcement-images', 'public'),
+    ]);
+    $oldPath = $announcement->image_path;
+    Storage::disk('public')->assertExists($oldPath);
+
+    $newFile = UploadedFile::fake()->image('new.jpg');
+
+    $response = $this->actingAs($admin)->put(
+        "/api/v1/admin/announcements/{$announcement->id}",
+        ['image' => $newFile]
+    );
+
+    $response->assertOk();
+
+    Storage::disk('public')->assertMissing($oldPath);
+
+    $newPath = $announcement->fresh()->image_path;
+    expect($newPath)->not->toBe($oldPath);
+    Storage::disk('public')->assertExists($newPath);
+});
+
+it('löscht das zugehörige bild mit wenn eine ankündigung gelöscht wird', function () {
+    Storage::fake('public');
+    $admin = User::factory()->admin()->create();
+    $file = UploadedFile::fake()->image('to-delete.jpg');
+    $announcement = Announcement::factory()->create([
+        'image_path' => $file->store('announcement-images', 'public'),
+    ]);
+    Storage::disk('public')->assertExists($announcement->image_path);
+
+    $response = $this->actingAs($admin)->deleteJson("/api/v1/admin/announcements/{$announcement->id}");
+
+    $response->assertNoContent();
+
+    Storage::disk('public')->assertMissing($announcement->image_path);
+    $this->assertDatabaseMissing('announcements', ['id' => $announcement->id]);
+});
+
+it('weist einen displayDays-wert außerhalb von 1 bis 365 mit 422 zurück', function () {
+    $admin = User::factory()->admin()->create();
+
+    $response = $this->actingAs($admin)->postJson('/api/v1/admin/announcements', [
+        'title' => 'Ungültige Dauer',
+        'body' => '<p>Text</p>',
+        'displayDays' => 400,
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['displayDays']);
+});
+
+it('akzeptiert einen displayDays-wert von genau 1 als untere grenze', function () {
+    $admin = User::factory()->admin()->create();
+
+    $response = $this->actingAs($admin)->postJson('/api/v1/admin/announcements', [
+        'title' => 'Kurzfristiger Hinweis',
+        'body' => '<p>Text</p>',
+        'displayDays' => 1,
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.displayDays', 1);
+});
+
+it('akzeptiert einen displayDays-wert von genau 365 als obere grenze', function () {
+    $admin = User::factory()->admin()->create();
+
+    $response = $this->actingAs($admin)->postJson('/api/v1/admin/announcements', [
+        'title' => 'Langfristiger Hinweis',
+        'body' => '<p>Text</p>',
+        'displayDays' => 365,
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.displayDays', 365);
+});
+
+it('weist das erstellen einer ankündigung ohne titel mit 422 zurück', function () {
+    $admin = User::factory()->admin()->create();
+
+    $response = $this->actingAs($admin)->postJson('/api/v1/admin/announcements', [
+        'body' => '<p>Text</p>',
+        'displayDays' => 7,
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['title']);
+});
+
+it('weist das erstellen einer ankündigung mit leerem body mit 422 zurück', function () {
+    $admin = User::factory()->admin()->create();
+
+    $response = $this->actingAs($admin)->postJson('/api/v1/admin/announcements', [
+        'title' => 'Titel ohne Text',
+        'body' => '',
+        'displayDays' => 7,
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['body']);
+});
+
+it('weist das erstellen einer ankündigung ohne body-feld mit 422 zurück', function () {
+    $admin = User::factory()->admin()->create();
+
+    $response = $this->actingAs($admin)->postJson('/api/v1/admin/announcements', [
+        'title' => 'Titel ohne Body-Feld',
+        'displayDays' => 7,
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['body']);
+});
+
+it('liefert am öffentlichen endpunkt ausschließlich die im ressourcenvertrag definierten felder', function () {
+    Announcement::factory()->create();
+
+    $response = $this->getJson('/api/v1/announcements');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                ['id', 'title', 'body', 'imageUrl', 'displayDays', 'expiresAt', 'isActive', 'createdAt', 'updatedAt'],
+            ],
+        ]);
+
+    expect(array_keys($response->json('data.0')))->toEqualCanonicalizing([
+        'id', 'title', 'body', 'imageUrl', 'displayDays', 'expiresAt', 'isActive', 'createdAt', 'updatedAt',
+    ]);
+});

--- a/backend/tests/Feature/Domain/AnnouncementModelTest.php
+++ b/backend/tests/Feature/Domain/AnnouncementModelTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Announcement;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+uses()->group('domain', 'announcement');
+
+it('berechnet expires_at beim erstellen aus created_at plus display_days', function () {
+    // Vergleich auf Sekundengenauigkeit: die `timestamp`-Spalte in der
+    // Migration hat keine Sub-Sekunden-Präzision (Standardpräzision 0),
+    // die DB rundet Mikrosekunden beim Speichern weg. `->fresh()` liest
+    // deshalb den tatsächlich persistierten (sekundengenauen) Wert.
+    $announcement = Announcement::factory()->create(['display_days' => 10])->fresh();
+
+    $expected = $announcement->created_at->copy()->addDays(10);
+
+    expect($announcement->expires_at->format('Y-m-d H:i:s'))->toBe($expected->format('Y-m-d H:i:s'));
+});
+
+it('liefert isActive true für eine frisch erstellte ankündigung', function () {
+    $announcement = Announcement::factory()->create(['display_days' => 30]);
+
+    expect($announcement->isActive())->toBeTrue();
+});
+
+it('liefert isActive false für eine ankündigung aus dem expired-factory-state', function () {
+    $announcement = Announcement::factory()->expired()->create();
+
+    expect($announcement->isActive())->toBeFalse();
+});
+
+it('berechnet expires_at beim erhöhen von display_days auf einer bestehenden ankündigung ab dem ursprünglichen created_at neu, nicht ab jetzt', function () {
+    $originalCreatedAt = now()->subDays(5);
+    $announcement = Announcement::factory()->create(['display_days' => 7]);
+    $announcement->forceFill(['created_at' => $originalCreatedAt])->saveQuietly();
+
+    $announcement->update(['display_days' => 20]);
+
+    $expected = $originalCreatedAt->copy()->addDays(20);
+
+    expect($announcement->fresh()->expires_at->format('Y-m-d H:i:s'))->toBe($expected->format('Y-m-d H:i:s'));
+});
+
+it('berechnet expires_at beim verringern von display_days auf einer bestehenden ankündigung ebenfalls ab dem ursprünglichen created_at neu', function () {
+    $originalCreatedAt = now()->subDays(3);
+    $announcement = Announcement::factory()->create(['display_days' => 30]);
+    $announcement->forceFill(['created_at' => $originalCreatedAt])->saveQuietly();
+
+    $announcement->update(['display_days' => 5]);
+
+    $expected = $originalCreatedAt->copy()->addDays(5);
+
+    expect($announcement->fresh()->expires_at->format('Y-m-d H:i:s'))->toBe($expected->format('Y-m-d H:i:s'));
+});
+
+it('lässt expires_at unverändert wenn beim aktualisieren nur der titel geändert wird und display_days gleich bleibt', function () {
+    $announcement = Announcement::factory()->create(['display_days' => 10]);
+    $originalExpiresAt = $announcement->expires_at->copy();
+
+    $announcement->update(['title' => 'Neuer Titel']);
+
+    expect($announcement->fresh()->expires_at->eq($originalExpiresAt))->toBeTrue();
+});
+
+it('scopeActive liefert nur datensätze mit expires_at in der zukunft', function () {
+    $active = Announcement::factory()->create();
+    Announcement::factory()->expired()->create();
+
+    $result = Announcement::active()->get();
+
+    expect($result)->toHaveCount(1);
+    expect($result->first()->id)->toBe($active->id);
+});
+
+it('scopeActive liefert eine leere sammlung wenn alle ankündigungen abgelaufen sind', function () {
+    Announcement::factory()->expired()->create();
+    Announcement::factory()->expired()->create();
+
+    $result = Announcement::active()->get();
+
+    expect($result)->toBeEmpty();
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,4964 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend",
+      "version": "0.0.0",
+      "dependencies": {
+        "@tiptap/pm": "^3.22.4",
+        "@tiptap/starter-kit": "^3.22.4",
+        "@tiptap/vue-3": "^3.22.4",
+        "dompurify": "^3.3.1",
+        "vue": "^3.5.24"
+      },
+      "devDependencies": {
+        "@headlessui/vue": "^1.7.23",
+        "@heroicons/vue": "^2.2.0",
+        "@playwright/test": "^1.57.0",
+        "@types/node": "^24.10.1",
+        "@vitejs/plugin-vue": "^6.0.1",
+        "@vue/test-utils": "^2.4.6",
+        "@vue/tsconfig": "^0.8.1",
+        "autoprefixer": "^10.4.23",
+        "axios": "^1.13.2",
+        "happy-dom": "^20.0.11",
+        "pinia": "^3.0.4",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^3.4.17",
+        "typescript": "~5.9.3",
+        "vite": "^7.2.4",
+        "vitest": "^4.0.16",
+        "vue-router": "^4.6.4",
+        "vue-tsc": "^3.1.4"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "npm:null@*"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@headlessui/vue": {
+      "version": "1.7.23",
+      "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.23.tgz",
+      "integrity": "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/vue-virtual": "^3.0.0-beta.60"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/@heroicons/vue": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-2.2.0.tgz",
+      "integrity": "sha512-G3dbSxoeEKqbi/DFalhRxJU4mTXJn7GwZ7ae8NuEQzd1bqdd0jAbdaBZlHPcvPD2xI1iGzNVB4k20Un2AguYPw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": ">= 3"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "name": "null",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/null/-/null-2.0.0.tgz",
+      "integrity": "sha512-CVSXPeB7Af0Sku7w8N8EKkgcwvQ6wGNfs6bly419A/q6dpIwzaHIk+65+La2g80ml21uxVXQo8xReTMI2WEYbA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.24.tgz",
+      "integrity": "sha512-A0k2qF0zFSUStXSZkGXABouXr2Tw2Ztl/cVIYG9qy84uR8W7UNjAcX3DvzBS3YnDcwvLxab8v7dbmYBZ39itDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
+      }
+    },
+    "node_modules/@tiptap/core": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.4.tgz",
+      "integrity": "sha512-ni2LWE52bVeSt3L2HVBSmbBw+elc32ATej9C68EyKzN/8vR5ILxFn6RCdDTKm4asmwZyq2jys12dKmBdWMr9QA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.23.4.tgz",
+      "integrity": "sha512-7YjSibNlPcy9eGK+tHt5G/Njr7nPxl+rZ3rCC6TwtLIRLSHPnoGDsfFOgTPkXxaQcE1a/VQwemnYfWc3kdIjDQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.23.4.tgz",
+      "integrity": "sha512-3L9tnZ12i+98u5df2nV2zGu/sc3rhI87E3ocn1YYAO8PJUAgZnMwdet8JawCrS1uut5sRKlxo3SXEmdNfRVm/w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.23.4.tgz",
+      "integrity": "sha512-EPTpL/IFp/aTGZErBq/Mc3dKznj6G/qNEkVYWjueOn1oKApyT0P6WVHGvu/vpMdErhzmoGDuFPPGVS6T8Upx2Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.23.4.tgz",
+      "integrity": "sha512-mXB2KZOz1R+E6VNTZ3vzdAk7ZDGKjPmsJEZIQg1B5qRycTKg49/rCCkLA2QnqAwX6BzS3mLLH1RWE2W0oXD7vg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.23.4.tgz",
+      "integrity": "sha512-C0TeRipMycUEBnV+Mzx6eLp/yZb6Vi/waP3Tkb0lO5/ikg7LWLB7AlmMunjIXEUcR/pJHID/aEh5PfJFpysUDg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.23.4.tgz",
+      "integrity": "sha512-UEU1w/85CSNKktbhESnIRmtjKcH7DeschReZA8err1wAnYLTKzid5ucnJSJ25iRg2V5Fnuws5gnPT5CVgdfXCQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.23.4.tgz",
+      "integrity": "sha512-YC4G6VkxT629rlqUTwD6XvOpxjvghn7fxrK4RbyKVJY2C6E1vgmX0won1Ast6v+qTE6iONOMS6f6VyPxSGjg4w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.23.4.tgz",
+      "integrity": "sha512-ujJQUIENk0RwVFCh5g/TOSEv1a7Pnam/cjHmSUqHWUNZkYS9aOqjm+JfURJPCinRS2oHvo3AARul5mkKgDJYcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.23.4.tgz",
+      "integrity": "sha512-eAc72bKM26yIPx0jsU8qdjE71vFNVu5R9jGbdItBMFc0SPLS4qY8g+8RJ+iWoLwbcSEpgooLS9D9sLfdAU+Tvw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.23.4.tgz",
+      "integrity": "sha512-RuyvOlIGP6UpVOc0Lw0L63jKLtYM49CNhPV2OMSfwwwbBZ3pJGos2/SqpYg71d3sn+qpsAopS4Pfr8iPZog73A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.23.4.tgz",
+      "integrity": "sha512-ODlpZCi7n136BH9luM09EFL8Pg+bbRCd0tzCQM5BKMXRkLitYZA8Gl/f5DLmGJ50wzFsDPXK2Br2g9UvZK7COg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.23.4.tgz",
+      "integrity": "sha512-8W9Hqi0J69Xbqg08nPf4xRMJXMccaKFAgUE1tvy5PAWJSQxOMwkKQXgZXxwe+80sOMUnV8qveBqUy/ODMPgAxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.23.4.tgz",
+      "integrity": "sha512-EA4kK8ywZ4dQNOdxeZbplmDDs5T5LjMgHpqxRwukj9wwKiILOK5E3fcKm1fCKh9Q02w96jax6YVccHwmgJP3sQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.23.4.tgz",
+      "integrity": "sha512-jUAHi+HZlg47BzgVIy6y/UH5vev7vPQ95jddhB5K3hC122kvWFMXlken7UOnqzbxNcHs2+4Oi/ZJirYMpT4P5w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.23.4.tgz",
+      "integrity": "sha512-XjxltY7MomwfTs6jmN6Bw5bb/upb34lpyqv2RiXppFTK25Br7ipksRjUpWpB4/csZeg30qwrLGVKxCol38ffrw==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.23.4.tgz",
+      "integrity": "sha512-yuauDm6qW/7q+ZO0YJBKQEGdnUm6DDTJM8AMp9bMZrT4jRf/zyUtNcZ91QEfFvBcyVuI+10PIOXtNPevhQ741Q==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.23.4.tgz",
+      "integrity": "sha512-Q/JXosShD5oyDwukE6igdrZD2lb0ZgyoQTHYchk0pzU4frClFbn3RI1wKP+XeqKLhdO6KH2WZ9rERGH7PtDi7Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.23.4.tgz",
+      "integrity": "sha512-9FezifCfuoc0o+5K6l4QNOOfelqxnDGg/f9oL1D/LFZPC54bPxpWWft9QCWOqyqZgyLCLjbCjciAlbgkrFUmmw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.23.4.tgz",
+      "integrity": "sha512-+3ofyssYnOTa1+nFWEmCAY1ngn8nAV1xo25JnNNC87NMU9WkSgr93jB7/uUJP0uui1C2dBLlaup3XXm108yarw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.23.4.tgz",
+      "integrity": "sha512-KbhXjCFzWphvFn5VU7E4dtmYDm+bssI1i0+CnXPWCXkjdaaX88ck68Xp1fKz8/bbI/CqlgiNDO/3TvqgtZ6woQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.23.4.tgz",
+      "integrity": "sha512-Vnq5vW801zPbu1LtKeA5k4R241jY+hRjXeijYwIPxy15KzIiipY12518HiCf6/8kkRbMxgOfdYg9X4BRV3HV3g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.23.4.tgz",
+      "integrity": "sha512-q9kxver/MR18p66aWZHSPycnr9hcBFyVGeGj8gf+BQCzn5hpvtSYTfLvk1nq8GFhygdQ9/e3f7B5ovrm/jnpvw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.23.4.tgz",
+      "integrity": "sha512-F1ocPT10LV+seky25R1TMCRdc/Iof99jLcDSYDGr6mNEDY4ct2RvOeSM8aDdYq6CkH+vXt3i3JDeRwV23KzswQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.23.4.tgz",
+      "integrity": "sha512-SlGPXauW8iKWG7wwuwC/0y/smLImp0h6GBIGgNnTBgIP/ThXQnjLMSZH0mW/REO87dQxkku01V3ARRywi+juhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.4.tgz",
+      "integrity": "sha512-+C5ngcoza47n3MjtjVBqBEBICPC0McdbwzJ+X6SSCviCLoqnSYanv5mIX9HWG0Q4fJ4BkdNM3VibZUxQaTbKyQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.23.4.tgz",
+      "integrity": "sha512-3VhU+NO6/ec9DMj/5Ej0nzARSq42cXnqW+QHCmTL3FNXkXQz+tw1KlfruT5GGJ3M0RssjWjRC0a39N/4S3qxeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.23.4",
+        "@tiptap/extension-blockquote": "^3.23.4",
+        "@tiptap/extension-bold": "^3.23.4",
+        "@tiptap/extension-bullet-list": "^3.23.4",
+        "@tiptap/extension-code": "^3.23.4",
+        "@tiptap/extension-code-block": "^3.23.4",
+        "@tiptap/extension-document": "^3.23.4",
+        "@tiptap/extension-dropcursor": "^3.23.4",
+        "@tiptap/extension-gapcursor": "^3.23.4",
+        "@tiptap/extension-hard-break": "^3.23.4",
+        "@tiptap/extension-heading": "^3.23.4",
+        "@tiptap/extension-horizontal-rule": "^3.23.4",
+        "@tiptap/extension-italic": "^3.23.4",
+        "@tiptap/extension-link": "^3.23.4",
+        "@tiptap/extension-list": "^3.23.4",
+        "@tiptap/extension-list-item": "^3.23.4",
+        "@tiptap/extension-list-keymap": "^3.23.4",
+        "@tiptap/extension-ordered-list": "^3.23.4",
+        "@tiptap/extension-paragraph": "^3.23.4",
+        "@tiptap/extension-strike": "^3.23.4",
+        "@tiptap/extension-text": "^3.23.4",
+        "@tiptap/extension-underline": "^3.23.4",
+        "@tiptap/extensions": "^3.23.4",
+        "@tiptap/pm": "^3.23.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/vue-3": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.23.4.tgz",
+      "integrity": "sha512-D8aUfiXSM1InPOe4jI4bBPSilz7bc42uVt5dMeto1cYYZrlzZEIe1vXvGm/0tvd/oVUtqQNk2Mjz+w0xoABT3Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.23.4",
+        "@tiptap/extension-floating-menu": "^3.23.4"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4",
+        "vue": "^3.0.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
+      "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+      "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.34",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+      "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+      "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.34",
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.14",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+      "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.9.tgz",
+      "integrity": "sha512-ie0ojt/0fU/GfIogh+zgHbaYRPlt9S+cLOxcWwF7nTSFh897BVgnFKL2byT4kpp1mlqYWZ2psGwSniyE2xsxYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.0",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+      "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+      "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+      "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.34",
+        "@vue/runtime-core": "3.5.34",
+        "@vue/shared": "3.5.34",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+      "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34"
+      },
+      "peerDependencies": {
+        "vue": "3.5.34"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+      "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.10.tgz",
+      "integrity": "sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/tsconfig": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.8.1.tgz",
+      "integrity": "sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "5.x",
+        "vue": "^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.356",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
+      "integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.6.tgz",
+      "integrity": "sha512-RIm+e9BiqAaJ1mRECv3vR3C+VG8ELoTTI+47tVudGi82yLnFOx3G/p/iSPK1HmHQdKhkkrJ68NJqxh7S+FBVmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+      "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-sfc": "3.5.34",
+        "@vue/runtime-dom": "3.5.34",
+        "@vue/server-renderer": "3.5.34",
+        "@vue/shared": "3.5.34"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.9.tgz",
+      "integrity": "sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.9.tgz",
+      "integrity": "sha512-qm8/nbo+9eZc1SCndm9wT+gq23pM+wRIdHY0wjm83B3lIginHTwcdrLUyTrKjDWXbMVNjKegNrnymhpdqnCL3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.2.9"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/api/announcements.test.ts
+++ b/frontend/src/api/announcements.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { announcementsApi, type Announcement } from '@/api/announcements'
+import apiClient from '@/api/client'
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+const sampleAnnouncement: Announcement = {
+  id: 3,
+  title: 'Kursausfall am 20.07.',
+  body: '<p>Der Welpenkurs am 20.07. entfällt <strong>krankheitsbedingt</strong>.</p>',
+  imageUrl: 'https://example.test/storage/announcement-images/xyz.jpg',
+  displayDays: 7,
+  expiresAt: '2026-07-24T10:00:00.000000Z',
+  isActive: true,
+  createdAt: '2026-07-17T10:00:00.000000Z',
+  updatedAt: '2026-07-17T10:00:00.000000Z',
+}
+
+describe('announcementsApi.getPublic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches the public endpoint and unwraps the data envelope', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { data: [sampleAnnouncement] } })
+
+    const result = await announcementsApi.getPublic()
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/announcements')
+    expect(result).toEqual([sampleAnnouncement])
+  })
+})
+
+describe('announcementsApi.getAll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches the admin endpoint and unwraps the data envelope', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { data: [sampleAnnouncement] } })
+
+    const result = await announcementsApi.getAll()
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/admin/announcements')
+    expect(result).toEqual([sampleAnnouncement])
+  })
+})
+
+describe('announcementsApi.create', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { data: sampleAnnouncement } })
+  })
+
+  it('sends the request via apiClient.post to the admin endpoint', async () => {
+    await announcementsApi.create({ title: 'Test', body: '<p>Test</p>', displayDays: 7 })
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1)
+    const [url] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect(url).toBe('/api/v1/admin/announcements')
+  })
+
+  it('sends the request with explicit multipart/form-data headers', async () => {
+    await announcementsApi.create({ title: 'Test', body: '<p>Test</p>', displayDays: 7 })
+
+    const [, , config] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect(config?.headers).toEqual({ 'Content-Type': 'multipart/form-data' })
+  })
+
+  it('sends a FormData body with the form fields', async () => {
+    await announcementsApi.create({ title: 'Test-Titel', body: '<p>Test</p>', displayDays: 14 })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect(formData).toBeInstanceOf(FormData)
+    expect((formData as FormData).get('title')).toBe('Test-Titel')
+    expect((formData as FormData).get('body')).toBe('<p>Test</p>')
+    expect((formData as FormData).get('displayDays')).toBe('14')
+  })
+
+  it('does not append a _method override field', async () => {
+    await announcementsApi.create({ title: 'Test', body: '<p>Test</p>', displayDays: 7 })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect((formData as FormData).has('_method')).toBe(false)
+  })
+
+  it('appends an image File when provided', async () => {
+    const image = new File(['image-bytes'], 'banner.png', { type: 'image/png' })
+
+    await announcementsApi.create({
+      title: 'Test',
+      body: '<p>Test</p>',
+      displayDays: 7,
+      image,
+    })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    const uploaded = (formData as FormData).get('image')
+    expect(uploaded).toBeInstanceOf(File)
+    expect((uploaded as File).name).toBe('banner.png')
+  })
+
+  it('omits the image field when no image is provided', async () => {
+    await announcementsApi.create({ title: 'Test', body: '<p>Test</p>', displayDays: 7 })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect((formData as FormData).has('image')).toBe(false)
+  })
+
+  it('resolves with the created announcement', async () => {
+    const result = await announcementsApi.create({
+      title: 'Test',
+      body: '<p>Test</p>',
+      displayDays: 7,
+    })
+
+    expect(result).toEqual(sampleAnnouncement)
+  })
+})
+
+describe('announcementsApi.update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { data: sampleAnnouncement } })
+  })
+
+  it('sends the request via apiClient.post, not apiClient.put', async () => {
+    await announcementsApi.update(3, { title: 'Neuer Titel' })
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1)
+    expect(apiClient.put).not.toHaveBeenCalled()
+  })
+
+  it('posts to the admin endpoint with the announcement id', async () => {
+    await announcementsApi.update(3, { title: 'Neuer Titel' })
+
+    const [url] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect(url).toBe('/api/v1/admin/announcements/3')
+  })
+
+  it('sends the request with explicit multipart/form-data headers', async () => {
+    await announcementsApi.update(3, { title: 'Neuer Titel' })
+
+    const [, , config] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect(config?.headers).toEqual({ 'Content-Type': 'multipart/form-data' })
+  })
+
+  it('appends a _method=PUT field to the FormData for method override', async () => {
+    await announcementsApi.update(3, { title: 'Neuer Titel' })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect(formData).toBeInstanceOf(FormData)
+    expect((formData as FormData).get('_method')).toBe('PUT')
+  })
+
+  it('sends only the changed fields for a partial update', async () => {
+    await announcementsApi.update(3, { displayDays: 21 })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    expect((formData as FormData).get('displayDays')).toBe('21')
+    expect((formData as FormData).has('title')).toBe(false)
+    expect((formData as FormData).has('body')).toBe(false)
+  })
+
+  it('appends a replacement image File when provided', async () => {
+    const image = new File(['new-image-bytes'], 'new-banner.png', { type: 'image/png' })
+
+    await announcementsApi.update(3, { image })
+
+    const [, formData] = vi.mocked(apiClient.post).mock.calls[0]!
+    const uploaded = (formData as FormData).get('image')
+    expect(uploaded).toBeInstanceOf(File)
+    expect((uploaded as File).name).toBe('new-banner.png')
+  })
+
+  it('resolves with the updated announcement', async () => {
+    const result = await announcementsApi.update(3, { title: 'Neuer Titel' })
+
+    expect(result).toEqual(sampleAnnouncement)
+  })
+})
+
+describe('announcementsApi.delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(apiClient.delete).mockResolvedValue({ data: null })
+  })
+
+  it('sends a DELETE request to the admin endpoint with the announcement id', async () => {
+    await announcementsApi.delete(3)
+
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/admin/announcements/3')
+  })
+})

--- a/frontend/src/api/announcements.ts
+++ b/frontend/src/api/announcements.ts
@@ -1,0 +1,109 @@
+import apiClient from './client'
+
+export interface Announcement {
+  id: number
+  title: string
+  body: string
+  imageUrl: string | null
+  displayDays: number
+  expiresAt: string | null
+  isActive: boolean
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+export interface AnnouncementFormData {
+  title: string
+  body: string
+  displayDays: number
+  image?: File | null
+}
+
+/**
+ * Builds a multipart FormData payload from partial announcement form data.
+ * Only defined keys are appended so `update()` can send partial updates
+ * without overwriting untouched fields with empty strings.
+ */
+function buildFormData(data: Partial<AnnouncementFormData>): FormData {
+  const formData = new FormData()
+  if (data.title !== undefined) formData.append('title', data.title)
+  if (data.body !== undefined) formData.append('body', data.body)
+  if (data.displayDays !== undefined) formData.append('displayDays', String(data.displayDays))
+  if (data.image) formData.append('image', data.image)
+  return formData
+}
+
+/**
+ * Announcements API
+ */
+export const announcementsApi = {
+  /**
+   * Get all currently active announcements (public, no auth required)
+   */
+  async getPublic(): Promise<Announcement[]> {
+    const response = await apiClient.get<{ data: Announcement[] }>('/api/v1/announcements')
+    return response.data.data
+  },
+
+  /**
+   * Get all announcements including expired ones (admin only)
+   */
+  async getAll(): Promise<Announcement[]> {
+    const response = await apiClient.get<{ data: Announcement[] }>('/api/v1/admin/announcements')
+    return response.data.data
+  },
+
+  /**
+   * Create a new announcement (admin only). Sent as multipart/form-data
+   * because an optional image upload may be included.
+   */
+  async create(data: AnnouncementFormData): Promise<Announcement> {
+    const response = await apiClient.post<{ data: Announcement }>(
+      '/api/v1/admin/announcements',
+      buildFormData(data),
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    )
+    return response.data.data
+  },
+
+  /**
+   * Update an existing announcement (admin only).
+   *
+   * Sent as POST with a Laravel method-override field (`_method=PUT`)
+   * instead of a real HTTP PUT. PHP only populates $_POST/$_FILES
+   * natively on a real POST request; parsing a multipart body on a
+   * real PUT is PHP-version-/server-dependent and drops uploaded
+   * files. Laravel's enableHttpMethodParameterOverride() rewrites the
+   * method from the `_method` field before routing, so the route
+   * stays `Route::put('/admin/announcements/{announcement}', ...)`.
+   */
+  async update(id: number, data: Partial<AnnouncementFormData>): Promise<Announcement> {
+    const formData = buildFormData(data)
+
+    // set() (not append()) so the override field cannot be shadowed by
+    // any future form field also named `_method`.
+    formData.set('_method', 'PUT')
+
+    const response = await apiClient.post<{ data: Announcement }>(
+      `/api/v1/admin/announcements/${id}`,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    )
+    return response.data.data
+  },
+
+  /**
+   * Delete an announcement (admin only)
+   */
+  async delete(id: number): Promise<void> {
+    await apiClient.delete(`/api/v1/admin/announcements/${id}`)
+  },
+}

--- a/frontend/src/components/AnnouncementBanner.integration.test.ts
+++ b/frontend/src/components/AnnouncementBanner.integration.test.ts
@@ -1,0 +1,70 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import AnnouncementBanner from '@/components/AnnouncementBanner.vue'
+import { announcementsApi } from '@/api/announcements'
+
+// Diese Datei mockt bewusst NICHT das useAnnouncements-Composable (im
+// Unterschied zu AnnouncementBanner.test.ts), sondern nur die
+// darunterliegende API-Schicht. So wird das reale Fehlerverhalten von
+// useAnnouncements().loadPublic() (try/catch, error-State bleibt intern,
+// announcements bleibt leer) im Zusammenspiel mit der Komponente geprüft
+// — nicht nur ein vorgetäuschtes leeres Ergebnis über einen Composable-Mock.
+vi.mock('@/api/announcements', async () => {
+  const actual = await vi.importActual<typeof import('@/api/announcements')>(
+    '@/api/announcements',
+  )
+  return {
+    ...actual,
+    announcementsApi: {
+      getPublic: vi.fn(),
+      getAll: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  }
+})
+
+describe('AnnouncementBanner mit echtem useAnnouncements-Composable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rendert keinen sichtbaren Bereich und stürzt nicht ab, wenn loadPublic einen Fehler wirft', async () => {
+    vi.mocked(announcementsApi.getPublic).mockRejectedValue(new Error('Netzwerkfehler'))
+
+    let mountError: unknown = null
+    let wrapper: ReturnType<typeof mount> | undefined
+    try {
+      wrapper = mount(AnnouncementBanner)
+      await flushPromises()
+    } catch (e) {
+      mountError = e
+    }
+
+    expect(mountError).toBeNull()
+    expect(wrapper!.find('section').exists()).toBe(false)
+  })
+
+  it('rendert eine Karte pro aktiver Ankündigung, wenn loadPublic erfolgreich lädt', async () => {
+    vi.mocked(announcementsApi.getPublic).mockResolvedValue([
+      {
+        id: 1,
+        title: 'Kursausfall',
+        body: '<p>Text</p>',
+        imageUrl: null,
+        displayDays: 7,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        isActive: true,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ])
+
+    const wrapper = mount(AnnouncementBanner)
+    await flushPromises()
+
+    expect(wrapper.find('section').exists()).toBe(true)
+    expect(wrapper.findAll('article')).toHaveLength(1)
+  })
+})

--- a/frontend/src/components/AnnouncementBanner.test.ts
+++ b/frontend/src/components/AnnouncementBanner.test.ts
@@ -1,0 +1,142 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import AnnouncementBanner from '@/components/AnnouncementBanner.vue'
+import { useAnnouncements } from '@/composables/useAnnouncements'
+import type { Announcement } from '@/api/announcements'
+
+vi.mock('@/composables/useAnnouncements', () => ({
+  useAnnouncements: vi.fn(),
+}))
+
+const mockedUseAnnouncements = vi.mocked(useAnnouncements)
+
+const withImage: Announcement = {
+  id: 1,
+  title: 'Kursausfall am 20.07.',
+  body: '<p>Der Welpenkurs entfällt <strong>krankheitsbedingt</strong>.</p>',
+  imageUrl: 'https://example.test/storage/announcement-images/xyz.jpg',
+  displayDays: 7,
+  expiresAt: '2026-07-24T10:00:00.000000Z',
+  isActive: true,
+  createdAt: '2026-07-17T10:00:00.000000Z',
+  updatedAt: '2026-07-17T10:00:00.000000Z',
+}
+
+const withoutImage: Announcement = {
+  id: 2,
+  title: 'Neue Öffnungszeiten',
+  body: '<p>Ab sofort gelten neue Öffnungszeiten.</p>',
+  imageUrl: null,
+  displayDays: 14,
+  expiresAt: '2026-07-31T10:00:00.000000Z',
+  isActive: true,
+  createdAt: '2026-07-17T10:00:00.000000Z',
+  updatedAt: '2026-07-17T10:00:00.000000Z',
+}
+
+/** Builds the mocked composable return value with the given announcements. */
+function stubUseAnnouncements(announcements: Announcement[]) {
+  const loadPublic = vi.fn().mockResolvedValue(undefined)
+  mockedUseAnnouncements.mockReturnValue({
+    announcements,
+    loading: false,
+    error: null,
+    loadPublic,
+    loadAll: vi.fn(),
+    createAnnouncement: vi.fn(),
+    updateAnnouncement: vi.fn(),
+    deleteAnnouncement: vi.fn(),
+  } as unknown as ReturnType<typeof useAnnouncements>)
+  return loadPublic
+}
+
+describe('AnnouncementBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rendert keinen sichtbaren Bereich, wenn keine aktiven Ankündigungen vorhanden sind', () => {
+    stubUseAnnouncements([])
+
+    const wrapper = mount(AnnouncementBanner)
+
+    expect(wrapper.find('section').exists()).toBe(false)
+  })
+
+  it('ruft loadPublic beim Mounten auf', () => {
+    const loadPublic = stubUseAnnouncements([])
+
+    mount(AnnouncementBanner)
+
+    expect(loadPublic).toHaveBeenCalledTimes(1)
+  })
+
+  it('rendert eine Karte pro aktiver Ankündigung', () => {
+    stubUseAnnouncements([withImage, withoutImage])
+
+    const wrapper = mount(AnnouncementBanner)
+
+    expect(wrapper.findAll('article')).toHaveLength(2)
+    expect(wrapper.text()).toContain('Kursausfall am 20.07.')
+    expect(wrapper.text()).toContain('Neue Öffnungszeiten')
+  })
+
+  it('rendert ein Bild, wenn imageUrl gesetzt ist', () => {
+    stubUseAnnouncements([withImage])
+
+    const wrapper = mount(AnnouncementBanner)
+
+    const img = wrapper.find('img')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe(withImage.imageUrl)
+    expect(img.attributes('alt')).toBe(withImage.title)
+  })
+
+  it('rendert kein Bild, wenn imageUrl null ist', () => {
+    stubUseAnnouncements([withoutImage])
+
+    const wrapper = mount(AnnouncementBanner)
+
+    expect(wrapper.find('img').exists()).toBe(false)
+  })
+
+  it('rendert erlaubtes HTML aus body über v-html', () => {
+    stubUseAnnouncements([withImage])
+
+    const wrapper = mount(AnnouncementBanner)
+
+    expect(wrapper.find('.announcement-body').html()).toContain('<strong>krankheitsbedingt</strong>')
+  })
+
+  it('entfernt <script>-Tags aus body (DOMPurify)', () => {
+    const unsafe: Announcement = {
+      ...withoutImage,
+      id: 3,
+      body: '<p>Text</p><script>alert(1)</script>',
+    }
+    stubUseAnnouncements([unsafe])
+
+    const wrapper = mount(AnnouncementBanner)
+
+    const html = wrapper.find('.announcement-body').html()
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('Text')
+  })
+
+  it('entfernt nicht erlaubte Tags und Inline-Event-Attribute aus body (DOMPurify)', () => {
+    const unsafe: Announcement = {
+      ...withoutImage,
+      id: 4,
+      body: '<p onclick="alert(1)">Text</p><img src="x" onerror="alert(1)">',
+    }
+    stubUseAnnouncements([unsafe])
+
+    const wrapper = mount(AnnouncementBanner)
+
+    const html = wrapper.find('.announcement-body').html()
+    expect(html).not.toContain('onclick')
+    expect(html).not.toContain('onerror')
+    expect(html).not.toContain('<img')
+    expect(html).toContain('Text')
+  })
+})

--- a/frontend/src/components/AnnouncementBanner.vue
+++ b/frontend/src/components/AnnouncementBanner.vue
@@ -29,7 +29,7 @@
 
 <script setup lang="ts">
 import { onMounted } from 'vue'
-import DOMPurify from 'dompurify'
+import createDOMPurify from 'dompurify'
 import { useAnnouncements } from '@/composables/useAnnouncements'
 
 const { announcements, loadPublic } = useAnnouncements()
@@ -40,9 +40,21 @@ const { announcements, loadPublic } = useAnnouncements()
  */
 const ALLOWED_TAGS = ['p', 'br', 'strong', 'em', 'h2', 'h3', 'ul', 'ol', 'li', 'blockquote', 'code', 'pre']
 
+/**
+ * DOMPurify's default export is a singleton bound to the `window` object
+ * that existed when the module was first loaded (see `createDOMPurify()`
+ * call with no arguments in dompurify's own source). In test environments
+ * where each test file gets a fresh global `window` (e.g. Vitest with
+ * happy-dom, one `window` per file), that singleton can end up bound to a
+ * stale `window` from an earlier-loaded test file, causing non-deterministic
+ * sanitization. Explicitly instantiating DOMPurify against the current
+ * `window` avoids relying on that module-load-time singleton and matches
+ * DOMPurify's documented pattern for non-standard/test environments.
+ */
 function sanitizeHtml(html: string): string {
   if (!html) return ''
-  return DOMPurify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR: [] })
+  const purify = createDOMPurify(window)
+  return purify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR: [] })
 }
 
 onMounted(() => loadPublic())

--- a/frontend/src/components/AnnouncementBanner.vue
+++ b/frontend/src/components/AnnouncementBanner.vue
@@ -1,0 +1,73 @@
+<template>
+  <section v-if="announcements.length" class="py-8 bg-amber-50 dark:bg-gray-900">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+      <article
+        v-for="announcement in announcements"
+        :key="announcement.id"
+        class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 flex flex-col sm:flex-row gap-6"
+      >
+        <img
+          v-if="announcement.imageUrl"
+          :src="announcement.imageUrl"
+          :alt="announcement.title"
+          class="w-full sm:w-48 h-48 object-cover rounded-lg flex-shrink-0"
+        >
+        <div class="flex-1 min-w-0">
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            {{ announcement.title }}
+          </h2>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div
+            class="text-gray-600 dark:text-gray-300 announcement-body"
+            v-html="sanitizeHtml(announcement.body)"
+          ></div>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import DOMPurify from 'dompurify'
+import { useAnnouncements } from '@/composables/useAnnouncements'
+
+const { announcements, loadPublic } = useAnnouncements()
+
+/**
+ * Allowed HTML tags consistent with the backend sanitization allowlist,
+ * mirroring frontend/src/views/courses/CoursesView.vue's ALLOWED_TAGS.
+ */
+const ALLOWED_TAGS = ['p', 'br', 'strong', 'em', 'h2', 'h3', 'ul', 'ol', 'li', 'blockquote', 'code', 'pre']
+
+function sanitizeHtml(html: string): string {
+  if (!html) return ''
+  return DOMPurify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR: [] })
+}
+
+onMounted(() => loadPublic())
+</script>
+
+<style scoped>
+.announcement-body :deep(p) {
+  margin: 0 0 0.5rem 0;
+}
+
+.announcement-body :deep(p:last-child) {
+  margin-bottom: 0;
+}
+
+.announcement-body :deep(ul),
+.announcement-body :deep(ol) {
+  padding-left: 1.25rem;
+  margin: 0.25rem 0;
+}
+
+.announcement-body :deep(ul) {
+  list-style-type: disc;
+}
+
+.announcement-body :deep(ol) {
+  list-style-type: decimal;
+}
+</style>

--- a/frontend/src/components/AnnouncementBanner.vue
+++ b/frontend/src/components/AnnouncementBanner.vue
@@ -54,19 +54,7 @@ const ALLOWED_TAGS = ['p', 'br', 'strong', 'em', 'h2', 'h3', 'ul', 'ol', 'li', '
 function sanitizeHtml(html: string): string {
   if (!html) return ''
   const purify = createDOMPurify(window)
-  const result = purify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR: [] })
-  // TEMPORARY CI DIAGNOSTIC — remove before merge
-  // eslint-disable-next-line no-console
-  console.error('[DOMPURIFY-DEBUG]', JSON.stringify({
-    input: html,
-    output: result,
-    version: (purify as unknown as { version?: string }).version,
-    isSupported: (purify as unknown as { isSupported?: boolean }).isSupported,
-    hasWindow: typeof window !== 'undefined',
-    hasDocument: typeof document !== 'undefined',
-    windowIsGlobalThis: typeof window !== 'undefined' && (window as unknown) === (globalThis as unknown),
-  }))
-  return result
+  return purify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR: [] })
 }
 
 onMounted(() => loadPublic())

--- a/frontend/src/components/AnnouncementBanner.vue
+++ b/frontend/src/components/AnnouncementBanner.vue
@@ -54,7 +54,19 @@ const ALLOWED_TAGS = ['p', 'br', 'strong', 'em', 'h2', 'h3', 'ul', 'ol', 'li', '
 function sanitizeHtml(html: string): string {
   if (!html) return ''
   const purify = createDOMPurify(window)
-  return purify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR: [] })
+  const result = purify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR: [] })
+  // TEMPORARY CI DIAGNOSTIC — remove before merge
+  // eslint-disable-next-line no-console
+  console.error('[DOMPURIFY-DEBUG]', JSON.stringify({
+    input: html,
+    output: result,
+    version: (purify as unknown as { version?: string }).version,
+    isSupported: (purify as unknown as { isSupported?: boolean }).isSupported,
+    hasWindow: typeof window !== 'undefined',
+    hasDocument: typeof document !== 'undefined',
+    windowIsGlobalThis: typeof window !== 'undefined' && (window as unknown) === (globalThis as unknown),
+  }))
+  return result
 }
 
 onMounted(() => loadPublic())

--- a/frontend/src/composables/useAnnouncements.test.ts
+++ b/frontend/src/composables/useAnnouncements.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { announcementsApi } from '@/api/announcements'
+import type { Announcement } from '@/api/announcements'
+import { useAnnouncements } from './useAnnouncements'
+
+vi.mock('@/api/announcements', () => ({
+  announcementsApi: {
+    getPublic: vi.fn(),
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+const makeAnnouncement = (id: number): Announcement => ({
+  id,
+  title: `Ankündigung ${id}`,
+  body: `<p>Text ${id}</p>`,
+  imageUrl: null,
+  displayDays: 7,
+  expiresAt: '2099-01-01T00:00:00.000Z',
+  isActive: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+})
+
+describe('useAnnouncements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('loadPublic()', () => {
+    it('befüllt announcements bei Erfolg, setzt loading auf false und loadError auf null', async () => {
+      const items = [makeAnnouncement(1)]
+      vi.mocked(announcementsApi.getPublic).mockResolvedValue(items)
+
+      const { announcements, loading, loadError, loadPublic } = useAnnouncements()
+
+      const promise = loadPublic()
+      expect(loading.value).toBe(true)
+      await promise
+
+      expect(announcements.value).toEqual(items)
+      expect(loading.value).toBe(false)
+      expect(loadError.value).toBeNull()
+    })
+
+    it('setzt loadError bei API-Fehler und belässt announcements leer', async () => {
+      vi.mocked(announcementsApi.getPublic).mockRejectedValue(new Error('Verbindungsfehler'))
+
+      const { announcements, loading, loadError, loadPublic } = useAnnouncements()
+      await loadPublic()
+
+      expect(loadError.value).toBe('Verbindungsfehler')
+      expect(announcements.value).toEqual([])
+      expect(loading.value).toBe(false)
+    })
+
+    it('setzt generische Fehlermeldung wenn kein Error-Objekt geworfen wird', async () => {
+      vi.mocked(announcementsApi.getPublic).mockRejectedValue('Unbekannter Fehler')
+
+      const { loadError, loadPublic } = useAnnouncements()
+      await loadPublic()
+
+      expect(loadError.value).toBe('Fehler beim Laden der Ankündigungen')
+    })
+  })
+
+  describe('loadAll()', () => {
+    it('befüllt announcements bei Erfolg (inkl. abgelaufener Einträge)', async () => {
+      const items = [makeAnnouncement(1), { ...makeAnnouncement(2), isActive: false }]
+      vi.mocked(announcementsApi.getAll).mockResolvedValue(items)
+
+      const { announcements, loadAll } = useAnnouncements()
+      await loadAll()
+
+      expect(announcements.value).toEqual(items)
+    })
+
+    it('setzt loadError bei API-Fehler', async () => {
+      vi.mocked(announcementsApi.getAll).mockRejectedValue(new Error('Serverfehler'))
+
+      const { loadError, loadAll } = useAnnouncements()
+      await loadAll()
+
+      expect(loadError.value).toBe('Serverfehler')
+    })
+  })
+
+  describe('createAnnouncement()', () => {
+    it('ruft announcementsApi.create() mit den Formulardaten auf und hängt die neue Ankündigung an', async () => {
+      const created = makeAnnouncement(10)
+      vi.mocked(announcementsApi.create).mockResolvedValue(created)
+
+      const { announcements, createAnnouncement } = useAnnouncements()
+      const payload = { title: 'Neu', body: '<p>Neu</p>', displayDays: 14 }
+      await createAnnouncement(payload)
+
+      expect(announcementsApi.create).toHaveBeenCalledWith(payload)
+      expect(announcements.value).toContainEqual(created)
+    })
+
+    it('setzt mutationError bei fehlgeschlagenem Erstellen und ändert announcements nicht', async () => {
+      vi.mocked(announcementsApi.create).mockRejectedValue(new Error('Validierungsfehler'))
+
+      const { announcements, mutationError, createAnnouncement } = useAnnouncements()
+      await createAnnouncement({ title: '', body: '', displayDays: 400 })
+
+      expect(mutationError.value).toBe('Validierungsfehler')
+      expect(announcements.value).toEqual([])
+    })
+  })
+
+  describe('updateAnnouncement()', () => {
+    it('ruft announcementsApi.update() mit der ID auf und ersetzt die Ankündigung in der Liste', async () => {
+      const original = makeAnnouncement(5)
+      const updated = { ...original, title: 'Geänderter Titel' }
+      vi.mocked(announcementsApi.getAll).mockResolvedValue([original])
+      vi.mocked(announcementsApi.update).mockResolvedValue(updated)
+
+      const { announcements, loadAll, updateAnnouncement } = useAnnouncements()
+      await loadAll()
+      await updateAnnouncement(5, { title: 'Geänderter Titel' })
+
+      expect(announcementsApi.update).toHaveBeenCalledWith(5, { title: 'Geänderter Titel' })
+      expect(announcements.value).toEqual([updated])
+    })
+
+    it('setzt mutationError bei fehlgeschlagenem Aktualisieren', async () => {
+      vi.mocked(announcementsApi.update).mockRejectedValue(new Error('Konflikt'))
+
+      const { mutationError, updateAnnouncement } = useAnnouncements()
+      await updateAnnouncement(5, { title: 'x' })
+
+      expect(mutationError.value).toBe('Konflikt')
+    })
+  })
+
+  describe('deleteAnnouncement()', () => {
+    it('ruft announcementsApi.delete() mit der ID auf und entfernt die Ankündigung aus der Liste', async () => {
+      const items = [makeAnnouncement(1), makeAnnouncement(2)]
+      vi.mocked(announcementsApi.getAll).mockResolvedValue(items)
+      vi.mocked(announcementsApi.delete).mockResolvedValue(undefined)
+
+      const { announcements, loadAll, deleteAnnouncement } = useAnnouncements()
+      await loadAll()
+      await deleteAnnouncement(1)
+
+      expect(announcementsApi.delete).toHaveBeenCalledWith(1)
+      expect(announcements.value).toHaveLength(1)
+      expect(announcements.value[0]!.id).toBe(2)
+    })
+
+    it('setzt mutationError bei fehlgeschlagenem Löschen und belässt die Liste unverändert', async () => {
+      const items = [makeAnnouncement(1)]
+      vi.mocked(announcementsApi.getAll).mockResolvedValue(items)
+      vi.mocked(announcementsApi.delete).mockRejectedValue(new Error('Löschen fehlgeschlagen'))
+
+      const { announcements, mutationError, loadAll, deleteAnnouncement } = useAnnouncements()
+      await loadAll()
+      await deleteAnnouncement(1)
+
+      expect(mutationError.value).toBe('Löschen fehlgeschlagen')
+      expect(announcements.value).toEqual(items)
+    })
+
+    it('löscht eine Ankündigung erfolgreich auch wenn zuvor ein Lade-Fehler aufgetreten war, ohne dass ein stiller mutationError zurückbleibt', async () => {
+      const items = [makeAnnouncement(1)]
+      vi.mocked(announcementsApi.getAll)
+        .mockRejectedValueOnce(new Error('Serverfehler'))
+        .mockResolvedValueOnce(items)
+      vi.mocked(announcementsApi.delete).mockResolvedValue(undefined)
+
+      const { announcements, loadError, mutationError, loadAll, deleteAnnouncement } =
+        useAnnouncements()
+      await loadAll()
+      expect(loadError.value).toBe('Serverfehler')
+
+      await loadAll()
+      await deleteAnnouncement(1)
+
+      expect(mutationError.value).toBeNull()
+      expect(announcements.value).toEqual([])
+    })
+  })
+})

--- a/frontend/src/composables/useAnnouncements.ts
+++ b/frontend/src/composables/useAnnouncements.ts
@@ -1,0 +1,99 @@
+import { ref } from 'vue'
+import {
+  announcementsApi,
+  type Announcement,
+  type AnnouncementFormData,
+} from '@/api/announcements'
+
+export function useAnnouncements() {
+  const announcements = ref<Announcement[]>([])
+  const loading = ref(false)
+  // Separate error refs for load vs. mutation operations (mirrors
+  // SettingsView.vue's loadError/saveError split, frontend/src/views/SettingsView.vue:565-566).
+  // A single shared error ref would make a stale mutation failure (e.g. a
+  // failed delete) hide the entire announcement list in the template, since
+  // the list rendering is gated by "no error" — even though the list itself
+  // is still fully loaded and valid.
+  const loadError = ref<string | null>(null)
+  const mutationError = ref<string | null>(null)
+
+  async function loadPublic(): Promise<void> {
+    loading.value = true
+    loadError.value = null
+    try {
+      announcements.value = await announcementsApi.getPublic()
+    } catch (e) {
+      loadError.value = e instanceof Error ? e.message : 'Fehler beim Laden der Ankündigungen'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loadAll(): Promise<void> {
+    loading.value = true
+    loadError.value = null
+    try {
+      announcements.value = await announcementsApi.getAll()
+    } catch (e) {
+      loadError.value = e instanceof Error ? e.message : 'Fehler beim Laden der Ankündigungen'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function createAnnouncement(data: AnnouncementFormData): Promise<void> {
+    loading.value = true
+    mutationError.value = null
+    try {
+      const created = await announcementsApi.create(data)
+      announcements.value = [...announcements.value, created]
+    } catch (e) {
+      mutationError.value = e instanceof Error ? e.message : 'Fehler beim Erstellen der Ankündigung'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function updateAnnouncement(
+    id: number,
+    data: Partial<AnnouncementFormData>,
+  ): Promise<void> {
+    loading.value = true
+    mutationError.value = null
+    try {
+      const updated = await announcementsApi.update(id, data)
+      announcements.value = announcements.value.map((announcement) =>
+        announcement.id === id ? updated : announcement,
+      )
+    } catch (e) {
+      mutationError.value = e instanceof Error ? e.message : 'Fehler beim Aktualisieren der Ankündigung'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function deleteAnnouncement(id: number): Promise<void> {
+    loading.value = true
+    mutationError.value = null
+    try {
+      await announcementsApi.delete(id)
+      announcements.value = announcements.value.filter((announcement) => announcement.id !== id)
+    } catch (e) {
+      mutationError.value = e instanceof Error ? e.message : 'Fehler beim Löschen der Ankündigung'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    announcements,
+    loading,
+    loadError,
+    mutationError,
+    loadPublic,
+    loadAll,
+    createAnnouncement,
+    updateAnnouncement,
+    deleteAnnouncement,
+  }
+}

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -116,6 +116,7 @@ import {
   CalendarIcon,
   DocumentTextIcon,
   Cog6ToothIcon,
+  MegaphoneIcon,
   ArrowRightOnRectangleIcon,
   SunIcon,
   MoonIcon,
@@ -228,6 +229,12 @@ const navigation = computed(() => {
       name: 'Einstellungen',
       to: { name: 'Settings' },
       icon: Cog6ToothIcon,
+      roles: ['admin']
+    },
+    {
+      name: 'Ankündigungen',
+      to: { name: 'Announcements' },
+      icon: MegaphoneIcon,
       roles: ['admin']
     },
     {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -130,6 +130,12 @@ const routes: RouteRecordRaw[] = [
         meta: { title: 'Systemeinstellungen', requiresAdmin: true }
       },
       {
+        path: 'announcements',
+        name: 'Announcements',
+        component: () => import('@/views/AnnouncementsView.vue'),
+        meta: { title: 'Ankündigungen', requiresAdmin: true }
+      },
+      {
         path: 'training-logs',
         name: 'TrainingLogs',
         component: () => import('@/views/training/TrainingLogsView.vue'),

--- a/frontend/src/views/AnnouncementsView.test.ts
+++ b/frontend/src/views/AnnouncementsView.test.ts
@@ -1,0 +1,355 @@
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import AnnouncementsView from '@/views/AnnouncementsView.vue'
+import FileUpload from '@/components/FileUpload.vue'
+import type { Announcement } from '@/api/announcements'
+
+// Variables starting with `mock` are hoisted alongside vi.mock by Vitest.
+// Real vue refs are required (not plain `{ value: ... }` objects) because
+// the component both reads `loadError.value`/`mutationError.value` in
+// script code (mirroring PricingItemForm.vue's pattern) AND relies on the
+// template compiler's `unref()` auto-unwrapping for `v-else-if="loadError"`
+// / `v-if="mutationError"` / `v-for="... in announcements"` — a plain
+// object without `__v_isRef` would be truthy regardless of its `.value`,
+// breaking the empty/error-state branching.
+//
+// loadError and mutationError are intentionally separate refs (not a single
+// shared `error`): a lingering mutation failure (e.g. a failed delete) must
+// not hide the still-valid, unchanged announcement list — see
+// useAnnouncements.ts for the full rationale.
+const mockAnnouncements = ref<Announcement[]>([])
+const mockLoading = ref(false)
+const mockLoadError = ref<string | null>(null)
+const mockMutationError = ref<string | null>(null)
+const mockLoadAll = vi.fn()
+const mockCreateAnnouncement = vi.fn()
+const mockUpdateAnnouncement = vi.fn()
+const mockDeleteAnnouncement = vi.fn()
+
+vi.mock('@/composables/useAnnouncements', () => ({
+  useAnnouncements: vi.fn(() => ({
+    announcements: mockAnnouncements,
+    loading: mockLoading,
+    loadError: mockLoadError,
+    mutationError: mockMutationError,
+    loadAll: mockLoadAll,
+    createAnnouncement: mockCreateAnnouncement,
+    updateAnnouncement: mockUpdateAnnouncement,
+    deleteAnnouncement: mockDeleteAnnouncement,
+  })),
+}))
+
+// HtmlEditor wraps Tiptap/ProseMirror which needs a real contenteditable
+// DOM environment; it is stubbed with a plain textarea so the v-model
+// contract (`modelValue` / `update:modelValue`) can still be exercised.
+const HtmlEditorStub = {
+  name: 'HtmlEditor',
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  template:
+    '<textarea data-testid="html-editor" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+}
+
+const activeAnnouncement: Announcement = {
+  id: 1,
+  title: 'Sommerpause',
+  body: '<p>Wir sind vom 1. bis 15. August im Urlaub.</p>',
+  imageUrl: 'https://example.com/announcement.jpg',
+  displayDays: 14,
+  expiresAt: '2099-01-01T00:00:00.000Z',
+  isActive: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+const expiredAnnouncement: Announcement = {
+  id: 2,
+  title: 'Altes Angebot',
+  body: '<p>Dieses Angebot ist abgelaufen.</p>',
+  imageUrl: null,
+  displayDays: 7,
+  expiresAt: '2020-01-01T00:00:00.000Z',
+  isActive: false,
+  createdAt: '2019-12-01T00:00:00.000Z',
+  updatedAt: '2019-12-01T00:00:00.000Z',
+}
+
+// Tracks the wrapper of the currently running test so it can be unmounted
+// afterwards. `mockAnnouncements`/`mockLoading`/`mockLoadError`/
+// `mockMutationError` are real, shared Vue refs (see comment above) —
+// without unmounting, a later test mutating those refs would still trigger
+// reactive updates on components mounted (and torn down by jsdom) in
+// earlier tests, causing "Cannot read properties of null" errors from stale
+// vnode trees.
+let wrapper: VueWrapper | undefined
+
+function mountView() {
+  wrapper = mount(AnnouncementsView, {
+    global: {
+      stubs: { HtmlEditor: HtmlEditorStub },
+    },
+  })
+  return wrapper
+}
+
+describe('AnnouncementsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAnnouncements.value = []
+    mockLoading.value = false
+    mockLoadError.value = null
+    mockMutationError.value = null
+    mockLoadAll.mockResolvedValue(undefined)
+    mockCreateAnnouncement.mockResolvedValue(undefined)
+    mockUpdateAnnouncement.mockResolvedValue(undefined)
+    mockDeleteAnnouncement.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = undefined
+    vi.unstubAllGlobals()
+  })
+
+  it('lädt alle Ankündigungen beim Mounten', () => {
+    mountView()
+    expect(mockLoadAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('zeigt einen Ladeindikator während des initialen Ladens', () => {
+    mockLoading.value = true
+    const wrapper = mountView()
+    expect(wrapper.find('.animate-spin').exists()).toBe(true)
+  })
+
+  it('zeigt die Fehlermeldung wenn das Laden fehlschlägt', () => {
+    mockLoadError.value = 'Fehler beim Laden der Ankündigungen'
+    const wrapper = mountView()
+    expect(wrapper.text()).toContain('Fehler beim Laden der Ankündigungen')
+  })
+
+  it('zeigt weiterhin die vorhandene Liste an, wenn eine Mutation fehlschlägt (Reviewer-Blocker)', () => {
+    mockAnnouncements.value = [activeAnnouncement, expiredAnnouncement]
+    mockMutationError.value = 'Fehler beim Löschen der Ankündigung'
+    const wrapper = mountView()
+
+    // The mutation error banner is shown ...
+    expect(wrapper.text()).toContain('Fehler beim Löschen der Ankündigung')
+    // ... but it must not hide the still-valid, unchanged list.
+    expect(wrapper.findAll('li')).toHaveLength(2)
+    expect(wrapper.text()).not.toContain('Noch keine Ankündigungen vorhanden')
+  })
+
+  it('zeigt einen Leerzustand wenn keine Ankündigungen vorhanden sind', () => {
+    const wrapper = mountView()
+    expect(wrapper.text()).toContain('Noch keine Ankündigungen vorhanden')
+  })
+
+  it('zeigt aktive und abgelaufene Ankündigungen jeweils mit korrektem Status-Badge', () => {
+    mockAnnouncements.value = [activeAnnouncement, expiredAnnouncement]
+    const wrapper = mountView()
+
+    const items = wrapper.findAll('li')
+    expect(items).toHaveLength(2)
+    const [activeItem, expiredItem] = items
+    expect(activeItem!.text()).toContain('Aktiv')
+    expect(activeItem!.find('.bg-green-100').exists()).toBe(true)
+    expect(expiredItem!.text()).toContain('Abgelaufen')
+    expect(expiredItem!.find('.bg-gray-100').exists()).toBe(true)
+  })
+
+  it('öffnet ein leeres Formular bei Klick auf "Neue Ankündigung"', async () => {
+    const wrapper = mountView()
+    await wrapper.find('button').trigger('click') // "Neue Ankündigung" is the first button
+    await nextTick()
+
+    expect(wrapper.find('#af-title').exists()).toBe(true)
+    expect(wrapper.find<HTMLInputElement>('#af-title').element.value).toBe('')
+    expect(wrapper.html()).toContain('Neue Ankündigung')
+  })
+
+  it('öffnet das Formular vorausgefüllt bei Klick auf "Bearbeiten"', async () => {
+    mockAnnouncements.value = [activeAnnouncement]
+    const wrapper = mountView()
+
+    const editButton = wrapper.findAll('button').find((btn) => btn.text() === 'Bearbeiten')
+    expect(editButton).toBeTruthy()
+    await editButton!.trigger('click')
+    await nextTick()
+
+    expect(wrapper.find<HTMLInputElement>('#af-title').element.value).toBe('Sommerpause')
+    expect(wrapper.find<HTMLInputElement>('#af-display-days').element.value).toBe('14')
+    expect(wrapper.find<HTMLTextAreaElement>('[data-testid="html-editor"]').element.value).toBe(
+      activeAnnouncement.body,
+    )
+  })
+
+  it('zeigt eine Fehlermeldung wenn der Titel beim Speichern leer ist', async () => {
+    const wrapper = mountView()
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+
+    await wrapper.find('#af-display-days').setValue(10)
+    await wrapper.find('form').trigger('submit')
+    await nextTick()
+
+    expect(wrapper.html()).toContain('Titel ist erforderlich')
+    expect(mockCreateAnnouncement).not.toHaveBeenCalled()
+  })
+
+  it('zeigt eine Fehlermeldung wenn die Anzeigedauer außerhalb von 1-365 liegt', async () => {
+    const wrapper = mountView()
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+
+    await wrapper.find('#af-title').setValue('Testtitel')
+    await wrapper.find('[data-testid="html-editor"]').setValue('Testtext')
+    await wrapper.find('#af-display-days').setValue(400)
+    await wrapper.find('form').trigger('submit')
+    await nextTick()
+
+    expect(wrapper.html()).toContain('Anzeigedauer muss zwischen 1 und 365 Tagen liegen')
+    expect(mockCreateAnnouncement).not.toHaveBeenCalled()
+  })
+
+  it('ruft createAnnouncement mit den Formulardaten auf und schließt das Formular', async () => {
+    const wrapper = mountView()
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+
+    await wrapper.find('#af-title').setValue('Neue Aktion')
+    await wrapper.find('[data-testid="html-editor"]').setValue('<p>Ein toller Text</p>')
+    await wrapper.find('#af-display-days').setValue(21)
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(mockCreateAnnouncement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Neue Aktion',
+        body: '<p>Ein toller Text</p>',
+        displayDays: 21,
+        image: null,
+      }),
+    )
+    expect(wrapper.find('#af-title').exists()).toBe(false)
+  })
+
+  it('ruft updateAnnouncement mit der ID der bearbeiteten Ankündigung auf', async () => {
+    mockAnnouncements.value = [activeAnnouncement]
+    const wrapper = mountView()
+
+    const editButton = wrapper.findAll('button').find((btn) => btn.text() === 'Bearbeiten')
+    await editButton!.trigger('click')
+    await nextTick()
+
+    await wrapper.find('#af-title').setValue('Geänderter Titel')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(mockUpdateAnnouncement).toHaveBeenCalledWith(
+      activeAnnouncement.id,
+      expect.objectContaining({ title: 'Geänderter Titel' }),
+    )
+    expect(mockCreateAnnouncement).not.toHaveBeenCalled()
+  })
+
+  it('setzt das ausgewählte Bild im Formular beim Datei-Upload', async () => {
+    const wrapper = mountView()
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+
+    await wrapper.find('#af-title').setValue('Mit Bild')
+    await wrapper.find('[data-testid="html-editor"]').setValue('Text')
+
+    const file = new File(['image-bytes'], 'banner.png', { type: 'image/png' })
+    await wrapper.findComponent(FileUpload).vm.$emit('upload', [file])
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(mockCreateAnnouncement).toHaveBeenCalledWith(
+      expect.objectContaining({ image: file }),
+    )
+  })
+
+  it('hält das Formular offen und zeigt einen Serverfehler wenn das Speichern fehlschlägt', async () => {
+    mockCreateAnnouncement.mockImplementation(async () => {
+      mockMutationError.value = 'Fehler beim Erstellen der Ankündigung'
+    })
+
+    const wrapper = mountView()
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+
+    await wrapper.find('#af-title').setValue('Titel')
+    await wrapper.find('[data-testid="html-editor"]').setValue('Text')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.find('#af-title').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Fehler beim Erstellen der Ankündigung')
+  })
+
+  it('hält das Formular offen und zeigt einen Serverfehler wenn das Aktualisieren fehlschlägt', async () => {
+    mockUpdateAnnouncement.mockImplementation(async () => {
+      mockMutationError.value = 'Fehler beim Aktualisieren der Ankündigung'
+    })
+    mockAnnouncements.value = [activeAnnouncement]
+
+    const wrapper = mountView()
+    const editButton = wrapper.findAll('button').find((btn) => btn.text() === 'Bearbeiten')
+    await editButton!.trigger('click')
+    await nextTick()
+
+    await wrapper.find('#af-title').setValue('Geänderter Titel')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.find('#af-title').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Fehler beim Aktualisieren der Ankündigung')
+  })
+
+  it('zeigt eine Fehlermeldung an wenn das Löschen fehlschlägt', async () => {
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true))
+    mockDeleteAnnouncement.mockImplementation(async () => {
+      mockMutationError.value = 'Fehler beim Löschen der Ankündigung'
+    })
+    mockAnnouncements.value = [activeAnnouncement]
+
+    const wrapper = mountView()
+    const deleteButton = wrapper.findAll('button').find((btn) => btn.text() === 'Löschen')
+    await deleteButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockDeleteAnnouncement).toHaveBeenCalledWith(activeAnnouncement.id)
+    expect(wrapper.text()).toContain('Fehler beim Löschen der Ankündigung')
+    // Reviewer-Blocker: a failed mutation must not hide the remaining,
+    // unchanged list behind the error message.
+    expect(wrapper.findAll('li')).toHaveLength(1)
+  })
+
+  it('löscht eine Ankündigung nach Bestätigung', async () => {
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true))
+    mockAnnouncements.value = [activeAnnouncement]
+    const wrapper = mountView()
+
+    const deleteButton = wrapper.findAll('button').find((btn) => btn.text() === 'Löschen')
+    await deleteButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockDeleteAnnouncement).toHaveBeenCalledWith(activeAnnouncement.id)
+  })
+
+  it('löscht eine Ankündigung nicht wenn die Bestätigung abgebrochen wird', async () => {
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(false))
+    mockAnnouncements.value = [activeAnnouncement]
+    const wrapper = mountView()
+
+    const deleteButton = wrapper.findAll('button').find((btn) => btn.text() === 'Löschen')
+    await deleteButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockDeleteAnnouncement).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/views/AnnouncementsView.vue
+++ b/frontend/src/views/AnnouncementsView.vue
@@ -1,0 +1,344 @@
+<template>
+  <div class="announcements-view">
+    <div class="flex justify-between items-center mb-6">
+      <div>
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Ankündigungen</h1>
+        <p class="mt-2 text-gray-600 dark:text-gray-400">
+          Verwalten Sie die auf der Startseite angezeigten Ankündigungen.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-primary"
+        @click="openNewForm"
+      >
+        Neue Ankündigung
+      </button>
+    </div>
+
+    <!-- Mutation Error State: reports create/update/delete failures without
+         hiding the (still valid, unchanged) list below -- kept outside the
+         loading/list v-if chain on purpose. -->
+    <div v-if="mutationError" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-6">
+      <p class="text-red-800 dark:text-red-400">{{ mutationError }}</p>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="loading && announcements.length === 0" class="flex justify-center items-center py-12">
+      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
+    </div>
+
+    <!-- Load Error State -->
+    <div v-else-if="loadError" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-6">
+      <p class="text-red-800 dark:text-red-400">{{ loadError }}</p>
+    </div>
+
+    <!-- Empty State -->
+    <div v-else-if="announcements.length === 0" class="card text-center text-gray-500 dark:text-gray-400">
+      Noch keine Ankündigungen vorhanden.
+    </div>
+
+    <!-- List -->
+    <ul v-else class="space-y-4">
+      <li
+        v-for="announcement in announcements"
+        :key="announcement.id"
+        class="card flex flex-col sm:flex-row sm:items-start gap-4"
+      >
+        <img
+          v-if="announcement.imageUrl"
+          :src="announcement.imageUrl"
+          :alt="announcement.title"
+          class="w-24 h-24 object-cover rounded-md flex-shrink-0"
+        />
+
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 flex-wrap">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {{ announcement.title }}
+            </h2>
+            <span
+              class="px-2 py-1 text-xs font-medium rounded-full"
+              :class="announcement.isActive ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'"
+            >
+              {{ announcement.isActive ? 'Aktiv' : 'Abgelaufen' }}
+            </span>
+          </div>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            {{ textPreview(announcement.body) }}
+          </p>
+          <p class="mt-2 text-xs text-gray-500 dark:text-gray-500">
+            Anzeigedauer: {{ announcement.displayDays }} {{ announcement.displayDays === 1 ? 'Tag' : 'Tage' }}
+            &middot; Läuft ab: {{ formatDate(announcement.expiresAt) }}
+          </p>
+        </div>
+
+        <div class="flex sm:flex-col gap-2 flex-shrink-0">
+          <button
+            type="button"
+            class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 font-medium text-sm"
+            @click="openEditForm(announcement)"
+          >
+            Bearbeiten
+          </button>
+          <button
+            type="button"
+            class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 font-medium text-sm"
+            @click="handleDelete(announcement)"
+          >
+            Löschen
+          </button>
+        </div>
+      </li>
+    </ul>
+
+    <!-- Create/Edit Form Modal -->
+    <div
+      v-if="showForm"
+      class="fixed inset-0 z-50 flex items-start justify-center bg-black/50 overflow-y-auto py-10"
+      @click.self="closeForm"
+    >
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-lg mx-4 flex flex-col">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 class="text-xl font-bold text-gray-900 dark:text-white">
+            {{ editingAnnouncement ? 'Ankündigung bearbeiten' : 'Neue Ankündigung' }}
+          </h2>
+          <button
+            type="button"
+            class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
+            aria-label="Formular schließen"
+            @click="closeForm"
+          >
+            <XMarkIcon class="w-6 h-6" />
+          </button>
+        </div>
+
+        <form class="p-6 space-y-4" @submit.prevent="handleSubmit">
+          <div
+            v-if="errors.general"
+            class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-md p-3"
+          >
+            <p class="text-sm text-red-800 dark:text-red-400">{{ errors.general }}</p>
+          </div>
+
+          <!-- Title -->
+          <div>
+            <label for="af-title" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Titel <span class="text-red-500">*</span>
+            </label>
+            <input
+              id="af-title"
+              v-model="form.title"
+              type="text"
+              maxlength="255"
+              class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+              :class="{ 'border-red-300 focus:border-red-500 focus:ring-red-500': errors.title }"
+            />
+            <p v-if="errors.title" class="mt-1 text-sm text-red-600 dark:text-red-400">
+              {{ errors.title }}
+            </p>
+          </div>
+
+          <!-- Body -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Text <span class="text-red-500">*</span>
+            </label>
+            <HtmlEditor v-model="form.body" />
+            <p v-if="errors.body" class="mt-1 text-sm text-red-600 dark:text-red-400">
+              {{ errors.body }}
+            </p>
+          </div>
+
+          <!-- Image -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Bild
+            </label>
+            <img
+              v-if="!form.image && editingAnnouncement?.imageUrl"
+              :src="editingAnnouncement.imageUrl"
+              alt="Aktuelles Bild"
+              class="w-20 h-20 object-cover rounded-md mb-2"
+            />
+            <FileUpload
+              :multiple="false"
+              accepted-types="image/*"
+              :auto-upload="true"
+              @upload="handleImageUpload"
+              @error="handleImageError"
+            />
+            <p v-if="errors.image" class="mt-1 text-sm text-red-600 dark:text-red-400">
+              {{ errors.image }}
+            </p>
+          </div>
+
+          <!-- Display Days -->
+          <div>
+            <label for="af-display-days" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Anzeigedauer (Tage) <span class="text-red-500">*</span>
+            </label>
+            <input
+              id="af-display-days"
+              v-model.number="form.displayDays"
+              type="number"
+              min="1"
+              max="365"
+              class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+              :class="{ 'border-red-300 focus:border-red-500 focus:ring-red-500': errors.displayDays }"
+            />
+            <p v-if="errors.displayDays" class="mt-1 text-sm text-red-600 dark:text-red-400">
+              {{ errors.displayDays }}
+            </p>
+          </div>
+
+          <!-- Actions -->
+          <div class="flex justify-end space-x-3 pt-2">
+            <button
+              type="button"
+              :disabled="saving"
+              class="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              @click="closeForm"
+            >
+              Abbrechen
+            </button>
+            <button
+              type="submit"
+              :disabled="saving"
+              class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <span v-if="saving">Speichern...</span>
+              <span v-else>{{ editingAnnouncement ? 'Aktualisieren' : 'Anlegen' }}</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, onMounted } from 'vue'
+import { XMarkIcon } from '@heroicons/vue/24/outline'
+import HtmlEditor from '@/components/HtmlEditor.vue'
+import FileUpload from '@/components/FileUpload.vue'
+import { useAnnouncements } from '@/composables/useAnnouncements'
+import type { Announcement, AnnouncementFormData } from '@/api/announcements'
+
+const {
+  announcements,
+  loading,
+  loadError,
+  mutationError,
+  loadAll,
+  createAnnouncement,
+  updateAnnouncement,
+  deleteAnnouncement,
+} = useAnnouncements()
+
+const showForm = ref(false)
+const editingAnnouncement = ref<Announcement | null>(null)
+const saving = ref(false)
+
+const form = reactive<AnnouncementFormData>({
+  title: '',
+  body: '',
+  displayDays: 30,
+  image: null,
+})
+
+const errors = reactive<Record<string, string>>({})
+
+/**
+ * Strips HTML tags from the sanitized rich-text body for a plain-text
+ * list preview, truncated to keep list rows compact.
+ */
+function textPreview(html: string, maxLength = 140): string {
+  const plainText = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+  return plainText.length > maxLength ? `${plainText.slice(0, maxLength)}…` : plainText
+}
+
+function formatDate(date: string | null): string {
+  if (!date) return '-'
+  return new Date(date).toLocaleDateString('de-DE')
+}
+
+function resetForm() {
+  form.title = ''
+  form.body = ''
+  form.displayDays = 30
+  form.image = null
+  Object.keys(errors).forEach((key) => delete errors[key])
+}
+
+function openNewForm() {
+  editingAnnouncement.value = null
+  resetForm()
+  showForm.value = true
+}
+
+function openEditForm(announcement: Announcement) {
+  editingAnnouncement.value = announcement
+  form.title = announcement.title
+  form.body = announcement.body
+  form.displayDays = announcement.displayDays
+  form.image = null
+  Object.keys(errors).forEach((key) => delete errors[key])
+  showForm.value = true
+}
+
+function closeForm() {
+  showForm.value = false
+  editingAnnouncement.value = null
+}
+
+function handleImageUpload(files: File[]) {
+  form.image = files[0] ?? null
+  delete errors.image
+}
+
+function handleImageError(message: string) {
+  errors.image = message
+}
+
+async function handleSubmit() {
+  Object.keys(errors).forEach((key) => delete errors[key])
+  if (!form.title.trim()) errors.title = 'Titel ist erforderlich'
+  if (!form.body.trim()) errors.body = 'Text ist erforderlich'
+  if (
+    form.displayDays === null ||
+    form.displayDays === undefined ||
+    !Number.isInteger(Number(form.displayDays)) ||
+    Number(form.displayDays) < 1 ||
+    Number(form.displayDays) > 365
+  ) {
+    errors.displayDays = 'Anzeigedauer muss zwischen 1 und 365 Tagen liegen'
+  }
+  if (Object.keys(errors).length > 0) return
+
+  saving.value = true
+  try {
+    if (editingAnnouncement.value) {
+      await updateAnnouncement(editingAnnouncement.value.id, { ...form })
+    } else {
+      await createAnnouncement({ ...form })
+    }
+    if (mutationError.value) {
+      errors.general = mutationError.value
+    } else {
+      closeForm()
+    }
+  } finally {
+    saving.value = false
+  }
+}
+
+async function handleDelete(announcement: Announcement) {
+  if (!window.confirm(`Ankündigung "${announcement.title}" wirklich löschen?`)) return
+  await deleteAnnouncement(announcement.id)
+}
+
+onMounted(() => {
+  loadAll()
+})
+</script>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -25,6 +25,8 @@
       </div>
     </section>
 
+    <AnnouncementBanner />
+
     <!-- Features Section -->
     <section class="py-16 bg-white dark:bg-gray-800">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -202,6 +204,7 @@ import {
   CurrencyEuroIcon
 } from '@heroicons/vue/24/outline'
 import backgroundImage from '@/assets/pet-01-1280x664.jpg'
+import AnnouncementBanner from '@/components/AnnouncementBanner.vue'
 import PricingModal from '@/components/PricingModal.vue'
 import { usePricingItems } from '@/composables/usePricingItems'
 

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/acceptance.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/acceptance.md
@@ -1,0 +1,238 @@
+# Abnahme: add-announcement-banner
+
+**Status:** bereit-für-user-review
+
+**Geprüft am:** 2026-07-17, auf Branch `feature/add-announcement-banner`
+(Working Tree, noch nicht committet).
+
+---
+
+## 0. Strukturelle Validität
+
+```
+$ openspec validate add-announcement-banner --strict
+Change 'add-announcement-banner' is valid
+```
+
+## 1. Vollständigkeit (tasks.md)
+
+Alle 11 Tasks (T01–T11) sind in `tasks.md` vollständig abgehakt (`[x]` auf
+allen Akzeptanzkriterien). Für jede Task existiert eine `task-T<ID>.notes.md`.
+Zusätzlich dokumentiert `task-T11.bugfix-review-blocker.notes.md` eine
+Nachkorrektur zu T11 (siehe Abschnitt 3).
+
+**Abweichung von der in `CLAUDE.md`/`WORKFLOW.md` beschriebenen
+Artefaktstruktur (nicht blockierend, aber zu dokumentieren):** Es existiert
+kein separates `task-T<ID>.review.md` pro Task, wie in
+`CLAUDE.md` Abschnitt 8 und `WORKFLOW.md` Schritt 9 vorgesehen. Stattdessen
+liegt ein einziger, changeweiter `task-report.test-report.md` (Tester) sowie
+eine einzelne `task-T11.bugfix-review-blocker.notes.md` (Entwickler-Notiz zur
+Behebung eines Reviewer-Befunds) vor. Der eine dokumentierte
+Reviewer-Blocker-Befund selbst ist inhaltlich nachvollziehbar beschrieben und
+nachweislich behoben (siehe Abschnitt 3) — es fehlt aber die formale
+`review.md`-Artefaktspur je Task. Empfehlung: kein Show-Stopper für dieses
+Gate, aber künftige Changes sollten die in `CLAUDE.md` Abschnitt 8
+vorgesehene Datei-Konvention einhalten, damit Review-Historie pro Task
+nachvollziehbar bleibt.
+
+## 2. Spec-Konformität (proposal.md "What Changes" gegen Code-Stand)
+
+Stichprobenartig gegen den tatsächlichen Diff (`git status`/gelesene
+Dateien, da noch nicht committet) geprüft:
+
+- **Migration** (`backend/database/migrations/2026_07_17_100000_create_announcements_table.php`):
+  Schema entspricht exakt `design.md` Abschnitt 2.2 (`id`, `title`, `body`,
+  `image_path` nullable, `unsignedSmallInteger display_days`,
+  `timestamp expires_at` nicht nullable, `timestamps()`, Index auf
+  `expires_at`). Ausschließlich treiberneutrale Blueprint-Methoden, kein raw
+  SQL — DB-Portabilitäts-Vorgabe aus `CLAUDE.md` Abschnitt 4.2 erfüllt.
+- **Model** (`backend/app/Models/Announcement.php`): `booted()`/`saving`-Hook,
+  `isActive()`, `scopeActive()` 1:1 wie in `design.md` Abschnitt 2.3
+  spezifiziert, gelesen und verglichen.
+- **Policy** (`backend/app/Policies/AnnouncementPolicy.php`): alle fünf
+  Methoden nur `isAdmin()`-Check, wie spezifiziert.
+- **FormRequests**: `StoreAnnouncementRequest`/`UpdateAnnouncementRequest`
+  nutzen `SanitizesHtmlContent`-Trait (keine neue Abhängigkeit, wie in
+  `proposal.md`/`design.md` Abschnitt 3 zugesagt), `image` erscheint korrekt
+  nicht in `validatedSnakeCase()`, `sometimes`-Regeln in Update-Request für
+  Teil-Updates.
+- **Resource** (`AnnouncementResource.php`): Feldnamen/Shape exakt wie im
+  verbindlichen JSON-Beispiel in `design.md` Abschnitt 5.1 (camelCase,
+  `imageUrl` via `Storage::disk('public')->url()`).
+- **Controller** (`AnnouncementController.php`): `publicIndex`/`index`/
+  `store`/`update`/`destroy` 1:1 wie in `design.md` Abschnitt 5.1 (inkl.
+  Bild-Löschung vor Ersetzung/beim Löschen).
+- **Routen** (`backend/routes/api.php`, `git diff` gelesen): Import
+  alphabetisch korrekt einsortiert, öffentliche Route
+  `GET /api/v1/announcements` außerhalb der `auth:sanctum`-Gruppe, vier
+  Admin-Routen innerhalb `auth:sanctum` + `can:admin` — exakt wie in
+  `design.md` Abschnitt 5.2 und in den Spec-Szenarien gefordert.
+- **Frontend API-Client** (`frontend/src/api/announcements.ts`): `create`
+  **und** `update` setzen explizit
+  `headers: { 'Content-Type': 'multipart/form-data' }` — der vom Skeptiker in
+  `verification.md` (Abschnitt "Widerlegt") aufgedeckte Fehlpunkt im
+  ursprünglichen `design.md`-Codevorschlag wurde in der tatsächlichen
+  Implementierung korrigiert (nicht der ursprüngliche fehlerhafte
+  Entwurfscode übernommen). `update()` sendet `POST` mit `_method=PUT`, kein
+  echtes HTTP-`PUT` — bestätigt.
+- **`AnnouncementBanner.vue`**: `v-if="announcements.length"` auf der
+  äußeren `<section>`, `DOMPurify.sanitize()` mit identischer
+  `ALLOWED_TAGS`-Liste wie `CoursesView.vue`, `v-html` mit
+  `eslint-disable-next-line vue/no-v-html`-Kommentar — bestätigt, exakt wie
+  spezifiziert.
+- **`HomeView.vue`**-Diff (`git diff` gelesen): `<AnnouncementBanner />`
+  exakt zwischen dem schließenden Hero-`</section>` und dem
+  `<!-- Features Section -->`-Kommentar eingefügt, Import ergänzt — exakt an
+  der in `design.md` Abschnitt 7.2 vorgegebenen Stelle.
+- **`AnnouncementsView.vue`**: Liste inkl. abgelaufener Ankündigungen mit
+  Status-Badge (`isActive`), `HtmlEditor`/`FileUpload`-Wiederverwendung,
+  Löschen mit Bestätigung — bestätigt.
+- **`router/index.ts`/`DefaultLayout.vue`**-Diffs (`git diff` gelesen): neue
+  Route `announcements` (`requiresAdmin: true`) exakt zwischen `settings`
+  und `training-logs`; neuer Navigationseintrag "Ankündigungen"
+  (`MegaphoneIcon`, `roles: ['admin']`) exakt zwischen "Einstellungen" und
+  "Kontakt" — jeweils exakt an den in `design.md` Abschnitt 8.2/8.3
+  vorgegebenen Stellen.
+
+Keine Abweichung zwischen `proposal.md`/`design.md` und dem tatsächlichen
+Code-Stand gefunden, mit Ausnahme der bereits im Skeptiker-`verification.md`
+dokumentierten und in der Implementierung korrekt behobenen Design-Lücke
+(fehlender Multipart-Header im ursprünglichen Codevorschlag).
+
+## 3. Review-Befunde (Reviewer)
+
+Ein "Muss"-Befund ist dokumentiert und geprüft:
+
+- **Blocker:** geteilter `error`-Ref in `useAnnouncements.ts` versteckte die
+  Ankündigungsliste in `AnnouncementsView.vue` bei fehlgeschlagenen
+  Mutationen (Lösch-/Update-Fehler), weil die Template-`v-if`/`v-else-if`-
+  Kette den Fehlerblock **statt** der Liste rendert, obwohl die Liste
+  weiterhin gültige Daten enthielt.
+- **Fix verifiziert:** `useAnnouncements.ts` wurde tatsächlich auf zwei
+  getrennte Refs (`loadError`/`mutationError`) umgestellt (gelesener
+  Code-Stand, siehe Abschnitt 2). `AnnouncementsView.vue` rendert
+  `mutationError` jetzt in einem eigenen, von der Lade-/Leer-/Listen-Kette
+  unabhängigen `<div v-if="mutationError">`-Block (Zeile 22 der Datei,
+  geprüft per `grep`) — die Liste (`<ul v-else>`) bleibt bei einem
+  Mutationsfehler sichtbar. Damit ist der Blocker sachlich behoben, nicht
+  nur kosmetisch.
+- Kein weiterer offener "Muss"-Befund in den vorliegenden Artefakten.
+
+## 4. Testergebnisse
+
+**Backend** (`docker compose exec php vendor/bin/pest`, selbst ausgeführt,
+nicht nur den Berichten vertraut):
+
+```
+Tests:    718 passed (2259 assertions)
+Duration: 26.62s
+```
+
+Deckt sich exakt mit dem im Tester-Report dokumentierten
+Nach-Ergänzungs-Stand (718 passed).
+
+**Frontend** (`npm run test -- --run`, selbst ausgeführt):
+
+```
+Test Files  17 passed (17)
+Tests       191 passed (191)
+```
+
+191 (nicht 189) — deckt sich mit dem Stand **nach** dem in
+`task-T11.bugfix-review-blocker.notes.md` dokumentierten Bugfix
+(189 Basis + 2 neue Testfälle für den Blocker-Nachweis).
+
+**Frontend-Build** (`npm run build`, selbst ausgeführt):
+
+```
+vue-tsc -b && vite build
+✓ 643 modules transformed.
+✓ built in 1.36s
+```
+
+Keine TypeScript-Fehler, keine Build-Warnungen (Akzeptanzkriterium gemäß
+`CLAUDE.md` Abschnitt "Projektspezifische Workflow-Regeln").
+
+Keine ungetesteten Akzeptanzkriterien aus `tasks.md` gefunden — die vom
+Tester ergänzten 29 Tests (14 Backend + 15 Frontend) schließen konkret
+benannte Lücken (Model-Ebene `display_days`-Neuberechnung ab ursprünglichem
+`created_at`, Composable-Fehlerpfade, Integrationstest mit echtem
+Composable, Update-/Delete-Fehlerfälle in der Admin-View).
+
+**Hinweis (kein Blocker):** Die in `CLAUDE.md`/`proposal.md` referenzierten
+Composer-Scripts (`composer qa`, `composer test`, `composer compat-check`)
+existieren weiterhin nicht in `backend/composer.json` (bereits im
+Vorgänger-Change `add-dog-owner-history-fields` und in diesem Change
+konsistent dokumentiert, siehe `proposal.md` "Out of Scope"). Ebenso fehlt
+`npm run lint` in `frontend/package.json`. Beides ist als bekannte,
+vorbestehende Lücke außerhalb des Scopes dieses Changes dokumentiert, nicht
+neu durch diesen Change eingeführt — kein Abnahme-Hindernis für
+`add-announcement-banner`, aber ein guter Kandidat für einen eigenen
+zukünftigen Change (bereits so vom Architekten in Modus A vermerkt).
+
+## 5. Spec-Delta-Konformität (`specs/announcement-management/spec.md`)
+
+Alle sieben Requirements gegen den tatsächlichen Code/Test-Stand geprüft:
+
+| Requirement | Status | Beleg |
+|---|---|---|
+| Admins can create announcements with rich text, image, display duration | erfüllt | `StoreAnnouncementRequest.php` (Regeln 1–365, `image` optional), `AnnouncementController::store()`, Tests in `AnnouncementApiTest.php` (Bild-Upload, Randwerte 1/365) |
+| Non-admins rejected (403/401) | erfüllt | Policy + `authorize()` in beiden FormRequests, vier eigene Tests in `AnnouncementApiTest.php` |
+| Body HTML sanitized server-side | erfüllt | `SanitizesHtmlContent`-Trait-Nutzung in beiden FormRequests, Test "rohes `<script>`/`onclick`-HTML wird entfernt" laut `tasks.md` T08 |
+| Multiple announcements active simultaneously | erfüllt | `publicIndex()` liefert Liste (`AnonymousResourceCollection`), kein Mechanismus zum Deaktivieren anderer Einträge; Test "liefert am öffentlichen endpunkt nur aktive ankündigungen" mit mehreren Datensätzen |
+| Expiry computed without scheduler | erfüllt | `booted()`/`saving`-Hook in `Announcement.php`, `scopeActive()`, keine Cron-/Queue-Abhängigkeit; Model-Tests in `AnnouncementModelTest.php` (u. a. "ändert `expires_at` nicht bei reiner Textänderung", "berechnet ab ursprünglichem `created_at`") |
+| Public landing page shows only active announcements, conditional section | erfüllt | `AnnouncementBanner.vue` `v-if="announcements.length"`, Platzierung in `HomeView.vue` verifiziert; `AnnouncementBanner.integration.test.ts` deckt Leer-/Fehlerfall ab |
+| Admin area lists all incl. expired, with status + delete removes image | erfüllt | `index()`-Endpunkt liefert alle, `AnnouncementsView.vue` Status-Badge nach `isActive`, `destroy()` löscht Bild-Datei; Tests in `AnnouncementApiTest.php` ("Admin-Endpunkt liefert auch abgelaufene", Lösch-Test mit `Storage::fake`) |
+
+Kein Requirement/Szenario ohne Code- und Test-Deckung gefunden.
+
+## Erfüllt
+
+- Alle 11 Tasks vollständig und nachvollziehbar umgesetzt, Code entspricht
+  `proposal.md`/`design.md` exakt (Stichproben mit Datei:Zeile-Beleg
+  durchgeführt, keine Abweichung außer der bereits korrigierten
+  Design-Lücke).
+- `openspec validate --strict` erfolgreich.
+- Backend-Testsuite komplett grün (718/718), Frontend-Testsuite komplett
+  grün (191/191), `npm run build` fehlerfrei ohne Warnungen.
+- Der einzige dokumentierte Reviewer-"Muss"-Befund (geteilter `error`-Ref)
+  ist nachweislich und korrekt behoben, inkl. Regressionstests.
+- Alle sieben Requirements aus `specs/announcement-management/spec.md` sind
+  durch Code und Tests gedeckt.
+- Shared-Hosting-Kompatibilität (kein Scheduler, kein raw SQL, keine neue
+  Abhängigkeit, treiberneutrale Migration) wie in `design.md` Abschnitt 10
+  behauptet, durch Codelektüre bestätigt.
+
+## Offen / Nacharbeit
+
+- **Nicht blockierend:** Fehlende formale `task-T<ID>.review.md`-Dateien pro
+  Task (siehe Abschnitt 1) — Prozessabweichung von `CLAUDE.md` Abschnitt 8,
+  aber der eine dokumentierte Reviewer-Befund selbst ist inhaltlich
+  nachvollziehbar und nachweislich behoben. Empfehlung: für künftige Changes
+  die Datei-Konvention einhalten.
+- **Nicht blockierend, bereits vorbestehend:** `composer qa`/`compat-check`/
+  `npm run lint` fehlen weiterhin im Projekt (dokumentiert in `proposal.md`
+  "Out of Scope", nicht durch diesen Change verursacht). Empfehlung: eigener
+  zukünftiger Change zur Einrichtung dieser Scripts.
+- **Zur Kenntnisnahme, kein Defekt:** Der Tester weist auf eine UX-Beobachtung
+  hin (nicht Teil der Akzeptanzkriterien): unmittelbar nach einem
+  fehlgeschlagenen Löschversuch wird kurzzeitig ein Fehlerbanner
+  **zusätzlich zur** Liste angezeigt (nach dem Bugfix korrekt, nicht mehr
+  "statt" der Liste) — funktional unbedenklich, keine Aktion nötig.
+- **Vor Push/PR laut `CLAUDE.md` Abschnitt 7.1 noch ausstehend:** Der
+  lokale MySQL-Gegentest der Migration wurde laut `task-T01.notes.md` bereits
+  über einen Ad-hoc-Container durchgeführt (da `docker-compose.mysql.yml`
+  im Projekt fehlt) — das ersetzt den in `CLAUDE.md` beschriebenen
+  Standard-Workflow-Schritt nicht vollständig, ist aber als gleichwertiger
+  Nachweis dokumentiert. Kein Abnahme-Hindernis, aber vor dem eigentlichen
+  `git push` sollte erneut geprüft werden, ob eine reguläre
+  `docker-compose.mysql.yml` inzwischen existiert.
+
+## Empfehlung an den User
+
+Der Change ist inhaltlich vollständig, spec-konform und vollständig
+grün getestet (718 Backend- + 191 Frontend-Tests, sauberer Build). Der
+einzige harte Reviewer-Befund ist behoben und verifiziert. Empfehlung:
+**Freigabe für User-Gate 2**, mit Kenntnisnahme der oben genannten
+nicht-blockierenden Prozess- und Altlast-Punkte (fehlende `review.md`-Dateien
+je Task, weiterhin fehlende QA-Scripts im Projekt).

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/ci-fix-dompurify-happy-dom.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/ci-fix-dompurify-happy-dom.notes.md
@@ -1,0 +1,108 @@
+# CI-Fix: DOMPurify/happy-dom-Isolationsproblem in `AnnouncementBanner.test.ts`
+
+**Kontext:** Direkter Fix auf `feature/add-announcement-banner` (bereits
+gemergter Stand von PR #70), kein neuer openspec-Change. Auftrag und
+Root-Cause-Hypothese siehe
+`openspec/triage/20260717173845-fix-dompurify-vitest-isolation-ci-flake.md`.
+
+## Root Cause (verifiziert)
+
+- `frontend/node_modules/dompurify/dist/purify.cjs.js:1535`:
+  `var purify = createDOMPurify();` — der Default-Export von `dompurify`
+  ist ein **Modul-Singleton**, das genau einmal beim ersten Laden des
+  Moduls erzeugt wird.
+- `frontend/node_modules/dompurify/dist/purify.cjs.js:396-398`:
+  `function createDOMPurify(root = window) { ... const DOMPurify = root =>
+  createDOMPurify(root); ... }` — `root` (Default: das zum Ladezeitpunkt
+  globale `window`) wird beim Erzeugen des Singletons fest gebunden. Das
+  zurückgegebene `DOMPurify`-Objekt ist selbst aufrufbar
+  (`(root?: WindowLike) => DOMPurify`, siehe
+  `frontend/node_modules/dompurify/dist/purify.es.d.mts:217-224`) und kann
+  so erneut mit einem anderen `window` instanziiert werden — genau das
+  macht der Fix.
+- `frontend/vitest.config.ts:8`: `environment: 'happy-dom'`. Vitest erzeugt
+  pro Testdatei ein **neues** `happy-dom`-`window`-Objekt, das
+  `dompurify`-Modul selbst wird aber pro Worker-Prozess nur **einmal**
+  importiert (Node-/ESM-Modul-Cache). Teilen sich mehrere Testdateien einen
+  Worker (abhängig von CPU-Kernzahl/Scheduling des jeweiligen Runners),
+  bleibt der `dompurify`-Default-Export an das `window` der zuerst
+  geladenen Testdatei gebunden — in der beobachteten CI-Fehlschlag-Reihenfolge
+  war das `src/views/courses/CoursesView.test.ts` (nutzt dasselbe
+  Sanitizing-Pattern), während `AnnouncementBanner.test.ts` mit dem
+  bereits "verbrauchten"/fremden `window` sanitized hat, wodurch DOMPurifys
+  interne Node-Type-Checks (`instanceof` etc. gegen das *aktuelle*
+  Test-`window`) nicht mehr griffen und weder `<script>` noch nicht
+  erlaubte `<img>`-Tags/Attribute entfernt wurden.
+- Lokal (macOS) reproduzierte sich das nicht zuverlässig, da Worker-Anzahl/
+  Datei-Verteilung von der auf `ubuntu-latest`/Node 20 abweicht — reines
+  Testumgebungs-/Nichtdeterminismus-Problem, kein Produktivcode-Bug (im
+  echten Browser existiert immer nur ein `window`).
+
+## Fix
+
+`frontend/src/components/AnnouncementBanner.vue`:
+
+- Import geändert von `import DOMPurify from 'dompurify'` zu
+  `import createDOMPurify from 'dompurify'` (reine lokale Umbenennung des
+  Default-Imports — es gibt in `dompurify@3.4.3` **keinen** separaten
+  Named Export `createDOMPurify`; der Default-Export selbst ist die
+  Factory-Funktion, siehe `purify.es.d.mts:217-224`,
+  `interface DOMPurify { (root?: WindowLike): DOMPurify; ... }`).
+- In `sanitizeHtml()` wird pro Aufruf `const purify = createDOMPurify(window)`
+  gebildet und `purify.sanitize(...)` statt des globalen Singletons
+  verwendet. Damit ist die Instanz immer explizit an das zum Aufrufzeitpunkt
+  aktuelle `window` gebunden — unabhängig davon, welches `window` beim
+  ersten Modul-Import zufällig global war.
+- Dies ist das von DOMPurify offiziell dokumentierte Muster für
+  nicht-Standard-Umgebungen/Tests (JSDoc-Kommentar der Factory-Funktion:
+  "Creates a DOMPurify instance using the given window-like object.
+  Defaults to `window`.").
+- Keine Änderung an Test-Erwartungen in `AnnouncementBanner.test.ts`
+  nötig — die Assertions bleiben unverändert korrekt.
+
+## Bewusst NICHT angefasst (außerhalb Scope)
+
+`frontend/src/views/courses/CoursesView.vue:153,320,324` nutzt exakt
+dasselbe anfällige Muster (`import DOMPurify from 'dompurify'` +
+`DOMPurify.sanitize(...)` über den Modul-Singleton). Aktuell traten dort
+keine CI-Fehlschläge auf (vermutlich reine Lade-/Worker-Reihenfolge-Glück),
+das Risiko besteht aber grundsätzlich identisch. **Empfehlung für einen
+Folge-Fix:** denselben `createDOMPurify(window)`-Pattern dort übernehmen,
+idealerweise in einem gemeinsamen Composable/Util (z. B.
+`frontend/src/composables/useSanitizedHtml.ts`), um Duplikation zwischen
+`AnnouncementBanner.vue` und `CoursesView.vue` zu vermeiden — das war aber
+laut Auftrag explizit außerhalb des Scopes dieses Fixes.
+
+`frontend/vitest.config.ts` wurde ebenfalls nicht angefasst (siehe
+Scope-Vorgabe) — eine projektweite Isolationsänderung
+(`pool`/`isolate`-Optionen) würde das Problem strukturell für alle
+Komponenten mit modul-globalem State lösen, hat aber einen größeren
+Blast-Radius (CI-Laufzeit-Impact) und war explizit nicht Teil dieses Fixes.
+
+## Verifikation
+
+- `npx vue-tsc -b` (via `npm run build`): keine TypeScript-Fehler. Der
+  umbenannte Default-Import (`createDOMPurify`) und der Aufruf
+  `createDOMPurify(window)` sind typkorrekt gegen
+  `frontend/node_modules/dompurify/dist/purify.es.d.mts` (Default-Export
+  hat Call-Signature `(root?: WindowLike): DOMPurify`).
+- `npm run build`: erfolgreich, `vue-tsc -b && vite build` ohne Fehler/
+  Warnings (Output u. a. `dist/assets/purify.es-*.js`, `dist/assets/index-*.js`).
+- `npx vitest run` (volle Suite, Standard-Worker-Verteilung): **4x
+  hintereinander ausgeführt** (1x initial + 3x explizit zur
+  Nichtdeterminismus-Prüfung) — jedes Mal `Test Files 17 passed (17)`,
+  `Tests 191 passed (191)`.
+- Zusätzlich `npx vitest run --no-file-parallelism` (erzwingt Ausführung
+  aller Testdateien in einem einzigen Prozess/Worker, damit garantiert
+  derselbe `dompurify`-Modul-Singleton über Dateigrenzen hinweg geteilt
+  wird — das Szenario, das den ursprünglichen CI-Fehler auslöste): Die
+  Dateireihenfolge in diesem Modus war u. a.
+  `src/views/courses/CoursesView.test.ts` **vor**
+  `src/components/AnnouncementBanner.test.ts` — exakt die in der Triage
+  beschriebene Problem-Reihenfolge. Ergebnis: weiterhin
+  `Test Files 17 passed (17)`, `Tests 191 passed (191)`. Das bestätigt,
+  dass der Fix das Problem unabhängig von Worker-/Datei-Reihenfolge löst.
+
+## Betroffene Dateien
+
+- `frontend/src/components/AnnouncementBanner.vue` (einzige Code-Änderung)

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/ci-fix-dompurify-happy-dom.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/ci-fix-dompurify-happy-dom.notes.md
@@ -1,108 +1,117 @@
-# CI-Fix: DOMPurify/happy-dom-Isolationsproblem in `AnnouncementBanner.test.ts`
+# CI-Fix: `AnnouncementBanner.test.ts` schlug in GitHub Actions fehl
 
 **Kontext:** Direkter Fix auf `feature/add-announcement-banner` (bereits
-gemergter Stand von PR #70), kein neuer openspec-Change. Auftrag und
-Root-Cause-Hypothese siehe
+gemergter Stand von PR #70), kein neuer openspec-Change. Ursprüngliche
+Root-Cause-Hypothese und Auftrag siehe
 `openspec/triage/20260717173845-fix-dompurify-vitest-isolation-ci-flake.md`.
 
-## Root Cause (verifiziert)
+## Chronologie
 
-- `frontend/node_modules/dompurify/dist/purify.cjs.js:1535`:
-  `var purify = createDOMPurify();` — der Default-Export von `dompurify`
-  ist ein **Modul-Singleton**, das genau einmal beim ersten Laden des
-  Moduls erzeugt wird.
-- `frontend/node_modules/dompurify/dist/purify.cjs.js:396-398`:
-  `function createDOMPurify(root = window) { ... const DOMPurify = root =>
-  createDOMPurify(root); ... }` — `root` (Default: das zum Ladezeitpunkt
-  globale `window`) wird beim Erzeugen des Singletons fest gebunden. Das
-  zurückgegebene `DOMPurify`-Objekt ist selbst aufrufbar
-  (`(root?: WindowLike) => DOMPurify`, siehe
-  `frontend/node_modules/dompurify/dist/purify.es.d.mts:217-224`) und kann
-  so erneut mit einem anderen `window` instanziiert werden — genau das
-  macht der Fix.
-- `frontend/vitest.config.ts:8`: `environment: 'happy-dom'`. Vitest erzeugt
-  pro Testdatei ein **neues** `happy-dom`-`window`-Objekt, das
-  `dompurify`-Modul selbst wird aber pro Worker-Prozess nur **einmal**
-  importiert (Node-/ESM-Modul-Cache). Teilen sich mehrere Testdateien einen
-  Worker (abhängig von CPU-Kernzahl/Scheduling des jeweiligen Runners),
-  bleibt der `dompurify`-Default-Export an das `window` der zuerst
-  geladenen Testdatei gebunden — in der beobachteten CI-Fehlschlag-Reihenfolge
-  war das `src/views/courses/CoursesView.test.ts` (nutzt dasselbe
-  Sanitizing-Pattern), während `AnnouncementBanner.test.ts` mit dem
-  bereits "verbrauchten"/fremden `window` sanitized hat, wodurch DOMPurifys
-  interne Node-Type-Checks (`instanceof` etc. gegen das *aktuelle*
-  Test-`window`) nicht mehr griffen und weder `<script>` noch nicht
-  erlaubte `<img>`-Tags/Attribute entfernt wurden.
-- Lokal (macOS) reproduzierte sich das nicht zuverlässig, da Worker-Anzahl/
-  Datei-Verteilung von der auf `ubuntu-latest`/Node 20 abweicht — reines
-  Testumgebungs-/Nichtdeterminismus-Problem, kein Produktivcode-Bug (im
-  echten Browser existiert immer nur ein `window`).
+1. **Erste Hypothese (widerlegt):** DOMPurifys Default-Export sei ein
+   Modul-Singleton, das beim ersten Import an ein "veraltetes" `window`
+   aus einer früher geladenen Testdatei gebunden bleibe
+   (`environment: 'happy-dom'`, ein `window` pro Testdatei, aber ein
+   ESM-Modul-Cache pro Worker). Fix-Versuch: `createDOMPurify(window)`
+   statt Default-Singleton in `frontend/src/components/AnnouncementBanner.vue`.
+   Lokal (auch via Docker mit Node 20, frischem `npm install`,
+   `--cpus=2`, `--no-file-parallelism`) **mehrfach verifiziert grün** —
+   aber **in CI weiterhin identisch fehlgeschlagen** nach dem Push. Das
+   widerlegt die Hypothese: Vitest isoliert Module korrekt pro Testdatei
+   (`isolate: true`, Standard), ein Singleton-Bleed über Dateigrenzen
+   findet so nicht statt.
+2. **Diagnose per temporärem Debug-Log** (`console.error` mit
+   `dompurify`-Version, Input/Output, `isSupported`, `hasWindow` in
+   `sanitizeHtml()`), committed, gepusht, CI-Log ausgelesen:
+   ```
+   [DOMPURIFY-DEBUG] {"input":"<p>Text</p><script>alert(1)</script>",
+   "output":"Text<script>alert(1)</script>","version":"3.4.12",
+   "isSupported":true,"hasWindow":true,"hasDocument":true,
+   "windowIsGlobalThis":true}
+   ```
+   **`version: "3.4.12"`** — lokal (und im Docker-Repro) war durchgehend
+   **`3.4.3`** installiert (per `npm ls dompurify` verifiziert, passend
+   zu `package-lock.json`). Unterschiedliche Paketversion zwischen CI und
+   lokal trotz identischem Commit.
+
+## Tatsächliche Root Cause (verifiziert)
+
+- `frontend/package-lock.json` war **nicht in Git getrackt** — Zeile 57
+  der Root-`.gitignore` enthielt `package-lock.json` (Kommentar: "keep
+  composer.lock, remove package-lock if using yarn"; das Projekt nutzt
+  aber npm, kein Yarn — es existiert kein `yarn.lock`). `git log --all
+  -- frontend/package-lock.json` lieferte keine Treffer; `git ls-files
+  frontend/package-lock.json` war leer.
+- Die CI-Workflow-Datei (`.github/workflows/ci.yml`, Job "Frontend
+  tests") führt `actions/checkout@v4` gefolgt von `npm install`
+  (working-directory `frontend`) aus. Ohne committtete
+  `package-lock.json` im Checkout resolved `npm install` bei **jedem**
+  CI-Lauf die jeweils neueste zum SemVer-Range (`^3.3.1`) passende
+  `dompurify`-Version neu aus der npm-Registry — das ergab `3.4.12` zum
+  Zeitpunkt der CI-Läufe dieses PRs, während die lokal (und in jedem
+  Docker-Repro, da dort das lokale, ungetrackte Lockfile ins Container
+  gemountet wurde) vorhandene `package-lock.json` durchgehend `3.4.3`
+  pinnte.
+- `dompurify@3.4.12` liefert mit identischer Konfiguration
+  (`{ ALLOWED_TAGS, ALLOWED_ATTR: [] }`) sichtbar fehlerhaftes Sanitizing
+  gegenüber `3.4.3` (siehe Debug-Log oben: `<script>` bleibt erhalten,
+  `<p>`-Wrapper wird trotz `ALLOWED_TAGS`-Mitgliedschaft entfernt) — ob
+  das ein Upstream-Regression-Bug in DOMPurify 3.4.4–3.4.12 ist, wurde
+  nicht weiter verfolgt (außerhalb Scope), ist für den Fix aber auch
+  irrelevant: **nicht-reproduzierbare Builds durch ein fehlendes Lockfile
+  sind der eigentliche, projektweite Fehler**, unabhängig davon, welche
+  konkrete Paketversion gerade betroffen ist.
+- `cache-dependency-path: frontend/package.json` (statt
+  `package-lock.json`) in `actions/setup-node@v4` war ein weiteres
+  Symptom derselben Lücke — der npm-Cache-Key hing nie am tatsächlichen
+  Lockfile.
 
 ## Fix
 
-`frontend/src/components/AnnouncementBanner.vue`:
-
-- Import geändert von `import DOMPurify from 'dompurify'` zu
-  `import createDOMPurify from 'dompurify'` (reine lokale Umbenennung des
-  Default-Imports — es gibt in `dompurify@3.4.3` **keinen** separaten
-  Named Export `createDOMPurify`; der Default-Export selbst ist die
-  Factory-Funktion, siehe `purify.es.d.mts:217-224`,
-  `interface DOMPurify { (root?: WindowLike): DOMPurify; ... }`).
-- In `sanitizeHtml()` wird pro Aufruf `const purify = createDOMPurify(window)`
-  gebildet und `purify.sanitize(...)` statt des globalen Singletons
-  verwendet. Damit ist die Instanz immer explizit an das zum Aufrufzeitpunkt
-  aktuelle `window` gebunden — unabhängig davon, welches `window` beim
-  ersten Modul-Import zufällig global war.
-- Dies ist das von DOMPurify offiziell dokumentierte Muster für
-  nicht-Standard-Umgebungen/Tests (JSDoc-Kommentar der Factory-Funktion:
-  "Creates a DOMPurify instance using the given window-like object.
-  Defaults to `window`.").
-- Keine Änderung an Test-Erwartungen in `AnnouncementBanner.test.ts`
-  nötig — die Assertions bleiben unverändert korrekt.
+1. **`.gitignore`**: Zeilen 56–57 (`# Package locks ...` /
+   `package-lock.json`) entfernt.
+2. **`frontend/package-lock.json`**: erstmals mit `git add -f`
+   committed. Enthält `dompurify@3.4.3`, lokal gegen die volle
+   Vitest-Suite (`191/191 grün`) und `vue-tsc -b`/`vite build`
+   verifiziert.
+3. **`.github/workflows/ci.yml`**: `cache-dependency-path` von
+   `frontend/package.json` auf `frontend/package-lock.json` korrigiert,
+   damit der npm-Cache-Key korrekt am Lockfile hängt.
+4. **`frontend/src/components/AnnouncementBanner.vue`**: die temporäre
+   Debug-Ausgabe wieder entfernt. Die zuvor eingeführte
+   `createDOMPurify(window)`-Bindung (statt Default-Singleton) **bleibt
+   bestehen** — sie ist zwar nicht die Ursache dieses konkreten Fehlers,
+   entspricht aber weiterhin dem offiziell dokumentierten DOMPurify-Muster
+   für Nicht-Standard-Umgebungen und schadet nicht.
 
 ## Bewusst NICHT angefasst (außerhalb Scope)
 
-`frontend/src/views/courses/CoursesView.vue:153,320,324` nutzt exakt
-dasselbe anfällige Muster (`import DOMPurify from 'dompurify'` +
-`DOMPurify.sanitize(...)` über den Modul-Singleton). Aktuell traten dort
-keine CI-Fehlschläge auf (vermutlich reine Lade-/Worker-Reihenfolge-Glück),
-das Risiko besteht aber grundsätzlich identisch. **Empfehlung für einen
-Folge-Fix:** denselben `createDOMPurify(window)`-Pattern dort übernehmen,
-idealerweise in einem gemeinsamen Composable/Util (z. B.
-`frontend/src/composables/useSanitizedHtml.ts`), um Duplikation zwischen
-`AnnouncementBanner.vue` und `CoursesView.vue` zu vermeiden — das war aber
-laut Auftrag explizit außerhalb des Scopes dieses Fixes.
-
-`frontend/vitest.config.ts` wurde ebenfalls nicht angefasst (siehe
-Scope-Vorgabe) — eine projektweite Isolationsänderung
-(`pool`/`isolate`-Optionen) würde das Problem strukturell für alle
-Komponenten mit modul-globalem State lösen, hat aber einen größeren
-Blast-Radius (CI-Laufzeit-Impact) und war explizit nicht Teil dieses Fixes.
+- `frontend/src/views/courses/CoursesView.vue` nutzt weiterhin den
+  DOMPurify-Default-Singleton ohne `createDOMPurify(window)`-Bindung.
+  Da die eigentliche Ursache (fehlendes Lockfile) jetzt behoben ist,
+  besteht hier kein akutes Risiko mehr; die defensive Umstellung auf
+  `createDOMPurify(window)` bliebe dennoch als optionaler
+  Konsistenz-Fix für einen späteren, eigenständigen Change offen.
+- Kein Audit der übrigen `package.json`-Abhängigkeiten auf weitere durch
+  das fehlende Lockfile verursachte Versionsabweichungen — dieser Fix
+  behebt die Lücke strukturell (zukünftige Installs sind deterministisch),
+  ein rückwirkender Vergleich aller bisher in CI tatsächlich installierten
+  Versionen wurde nicht durchgeführt.
+- `npm audit` meldete beim lokalen `npm install` 6 Schwachstellen
+  (1 low, 1 moderate, 4 high) in Dependencies — vorbestehender Zustand,
+  nicht Teil dieses Fixes, aber erwähnenswert für einen möglichen
+  Folge-Change.
 
 ## Verifikation
 
-- `npx vue-tsc -b` (via `npm run build`): keine TypeScript-Fehler. Der
-  umbenannte Default-Import (`createDOMPurify`) und der Aufruf
-  `createDOMPurify(window)` sind typkorrekt gegen
-  `frontend/node_modules/dompurify/dist/purify.es.d.mts` (Default-Export
-  hat Call-Signature `(root?: WindowLike): DOMPurify`).
-- `npm run build`: erfolgreich, `vue-tsc -b && vite build` ohne Fehler/
-  Warnings (Output u. a. `dist/assets/purify.es-*.js`, `dist/assets/index-*.js`).
-- `npx vitest run` (volle Suite, Standard-Worker-Verteilung): **4x
-  hintereinander ausgeführt** (1x initial + 3x explizit zur
-  Nichtdeterminismus-Prüfung) — jedes Mal `Test Files 17 passed (17)`,
-  `Tests 191 passed (191)`.
-- Zusätzlich `npx vitest run --no-file-parallelism` (erzwingt Ausführung
-  aller Testdateien in einem einzigen Prozess/Worker, damit garantiert
-  derselbe `dompurify`-Modul-Singleton über Dateigrenzen hinweg geteilt
-  wird — das Szenario, das den ursprünglichen CI-Fehler auslöste): Die
-  Dateireihenfolge in diesem Modus war u. a.
-  `src/views/courses/CoursesView.test.ts` **vor**
-  `src/components/AnnouncementBanner.test.ts` — exakt die in der Triage
-  beschriebene Problem-Reihenfolge. Ergebnis: weiterhin
-  `Test Files 17 passed (17)`, `Tests 191 passed (191)`. Das bestätigt,
-  dass der Fix das Problem unabhängig von Worker-/Datei-Reihenfolge löst.
+- `npm ls dompurify` (lokal, nach `npm install` mit committeter
+  Lockfile): `dompurify@3.4.3`.
+- `npx vitest run`: `Test Files 17 passed (17)`, `Tests 191 passed (191)`.
+- `npx vue-tsc -b`: keine TypeScript-Fehler.
+- CI-Lauf nach diesem Commit: siehe PR #70, Checks-Status.
 
 ## Betroffene Dateien
 
-- `frontend/src/components/AnnouncementBanner.vue` (einzige Code-Änderung)
+- `.gitignore`
+- `frontend/package-lock.json` (neu committed)
+- `.github/workflows/ci.yml`
+- `frontend/src/components/AnnouncementBanner.vue` (Debug-Log entfernt)

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/design.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/design.md
@@ -1,0 +1,851 @@
+# Design: add-announcement-banner
+
+**Change-ID:** add-announcement-banner
+**Datum:** 2026-07-17
+
+---
+
+## 1. Kontext / Entscheidungen des Users (2026-07-17)
+
+Aus `openspec/triage/20260717103000-announcement-banner.md`, Abschnitt
+"Entscheidungen des Users":
+
+1. **Ablauf-Berechnung:** anzeigeseitig (`created_at`/`published_at` +
+   `display_days` < `now()`), **kein** Scheduler/Cron-Task.
+2. **Mehrfach-Ankündigungen:** mehrere gleichzeitig aktive Ankündigungen
+   möglich (Liste, kein Überschreiben einer einzelnen Ankündigung).
+3. **Bilder:** genau ein Bild pro Ankündigung.
+4. **Text-Format:** Rich-Text (HTML) — Editor + serverseitiges Sanitizing.
+5. **Admin-Historie:** abgelaufene Ankündigungen bleiben im Admin-Bereich
+   sichtbar (Status-Badge aktiv/abgelaufen), keine automatische Löschung.
+
+Diese fünf Entscheidungen bestimmen das Datenmodell (Abschnitt 2) und die
+API-Form (Abschnitt 5) direkt.
+
+---
+
+## 2. Datenmodell
+
+### 2.1 Warum ein berechnetes, aber **persistiertes** `expires_at` statt reiner Laufzeit-Berechnung?
+
+CLAUDE.md Abschnitt 4.2 verbietet Datums-Arithmetik in raw SQL
+(`whereRaw`, `DB::raw`), weil MySQL (`DATE_ADD(created_at, INTERVAL
+display_days DAY)`) und PostgreSQL (`created_at + (display_days ||
+' days')::interval`) inkompatible Syntax verwenden. Eine reine
+Eloquent-`where`-Klausel kann aber keine Spalten-Arithmetik ausdrücken.
+
+**Korrektur nach Skeptiker-Prüfung (verifiziert):** `Announcement` ist
+**kein** Fall von "Ablauf-Berechnung", die per Model-Hook aus einem anderen
+Feld hergeleitet wird — dieses konkrete Vorgehen ist im Projekt **neu**.
+`backend/app/Models/CustomerCredit.php` enthält **keinen**
+`booted()`/`saving`-Hook: `expiration_date` wird dort direkt vom Client im
+Request übergeben (`StoreCustomerCreditRequest.php:70`,
+`UpdateCustomerCreditRequest.php:61`) bzw. in der Factory hartkodiert
+gesetzt (`CustomerCreditFactory.php:29,42,58`), niemals aus einem anderen
+Feld berechnet. Nur die **nachgelagerte Filterung** — ein bereits
+persistiertes Ablaufdatum per reiner, treiberneutraler
+Eloquent-`where`-Bedingung abfragen (`scopeActive()`/`scopeExpired()`,
+`CustomerCredit.php:121-138`) — ist ein tatsächlicher Präzedenzfall und
+wird hier sinngemäß übernommen.
+
+`Announcement` geht insofern über dieses Präzedenzmuster hinaus, als
+`expires_at` **zusätzlich** aus einem anderen Feld (`display_days` +
+Erstellungszeitpunkt) hergeleitet statt direkt vom Client übergeben wird.
+Das ist die richtige Wahl für dieses Feature, weil `display_days` (nicht
+ein Datum) die vom User festgelegte fachliche Eingabegröße ist (siehe
+Nutzerentscheidung 1) — ein `booted()`/`saving`-Hook ist der naheliegende
+Ort, um diese Ableitung zentral und konsistent (Create **und** Update)
+umzusetzen, statt sie in Controller/FormRequest zu duplizieren (DRY). Die
+Begründung für den Ansatz selbst bleibt bestehen: reine PHP-/Carbon-
+Berechnung beim Speichern, kein raw SQL, kein Scheduler, MySQL/PostgreSQL-
+portabel — nur eben als **neu eingeführtes** Muster, nicht als
+Wiederverwendung eines bestehenden Hooks.
+
+`Announcement` speichert `expires_at` beim Erstellen/Aktualisieren aus
+`created_at` (bzw. `now()` bei einem neuen, noch nicht persistierten
+Datensatz) + `display_days` berechnet in einer eigenen Spalte. Das ist
+weiterhin "anzeigeseitig berechnet" im Sinne der Nutzerentscheidung — es
+läuft **kein** Hintergrundprozess, der periodisch `expires_at`
+aktualisiert oder Datensätze verändert; die Spalte
+wird ausschließlich beim (durch einen Admin ausgelösten) Speichern
+neu berechnet, die Aktiv-Prüfung selbst (`expires_at > now()`) findet erst
+beim Lesen/Anzeigen statt.
+
+### 2.2 Migration
+
+`backend/database/migrations/2026_07_17_100000_create_announcements_table.php`
+(neu):
+
+```php
+Schema::create('announcements', function (Blueprint $table) {
+    $table->id();
+    $table->string('title', 255);
+    $table->text('body');
+    $table->string('image_path')->nullable();
+    $table->unsignedSmallInteger('display_days');
+    $table->timestamp('expires_at');
+    $table->timestamps();
+
+    $table->index('expires_at');
+});
+```
+
+`down()`: `Schema::dropIfExists('announcements');`
+
+**DB-Portabilität (CLAUDE.md Abschnitt 4.2 — Pflichtprüfung):**
+
+- Ausschließlich treiberneutrale Blueprint-Typen (`id`, `string`, `text`,
+  `unsignedSmallInteger`, `timestamp`, `timestamps`, `index`) — kein
+  `jsonb`, kein `uuid`, kein raw SQL, kein `DB::statement()`.
+- `expires_at` ist bewusst **nicht nullable**: Der Wert wird immer aus dem
+  Pflichtfeld `display_days` berechnet (siehe 2.3), es gibt keinen validen
+  Zustand, in dem eine Ankündigung ohne Ablaufzeitpunkt existiert. Die
+  DB-Constraint erzwingt diese Invariante zusätzlich zur Anwendungslogik.
+- **Pflicht für T01 (dev-php):** Migration lokal gegen MySQL **und**
+  PostgreSQL laufen lassen (`docker compose -f docker-compose.yml -f
+  docker-compose.mysql.yml up -d`, `php artisan migrate:fresh`), gemäß
+  CLAUDE.md Abschnitt 7.1.
+
+### 2.3 Model `backend/app/Models/Announcement.php` (neu)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Announcement Model
+ *
+ * @property int $id
+ * @property string $title
+ * @property string $body
+ * @property string|null $image_path
+ * @property int $display_days
+ * @property \Illuminate\Support\Carbon $expires_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class Announcement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'body',
+        'image_path',
+        'display_days',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'display_days' => 'integer',
+            'expires_at' => 'datetime',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Recompute expires_at from the original publish date whenever
+     * display_days changes (create, or admin extends/shortens the
+     * display duration on an existing announcement). Uses the existing
+     * created_at as the base on update so editing an announcement does
+     * not silently reset its display window to "now".
+     */
+    protected static function booted(): void
+    {
+        static::saving(function (Announcement $announcement): void {
+            if (! $announcement->exists || $announcement->isDirty('display_days')) {
+                $base = ($announcement->exists && $announcement->created_at)
+                    ? $announcement->created_at
+                    : now();
+
+                $announcement->expires_at = $base->copy()->addDays((int) $announcement->display_days);
+            }
+        });
+    }
+
+    /**
+     * Whether the announcement is currently within its display window.
+     */
+    public function isActive(): bool
+    {
+        return $this->expires_at->isFuture();
+    }
+
+    /**
+     * Scope a query to only include currently active announcements.
+     */
+    public function scopeActive($query)
+    {
+        return $query->where('expires_at', '>', now());
+    }
+}
+```
+
+`backend/database/factories/AnnouncementFactory.php` (neu): Standard-Faker
+für `title`/`body`/`display_days` (z. B. `display_days` zwischen 1 und 30).
+`expires_at` wird **nicht** in der Factory gesetzt — das `saving`-Event des
+Models berechnet es automatisch beim `create()`. Für Tests, die einen
+bereits **abgelaufenen** Datensatz brauchen, definiert die Factory einen
+State `expired()`:
+
+```php
+public function expired(): static
+{
+    return $this->afterCreating(function (Announcement $announcement) {
+        $announcement->forceFill([
+            'created_at' => now()->subDays(10),
+            'expires_at' => now()->subDays(9),
+        ])->saveQuietly();
+    });
+}
+```
+
+`saveQuietly()` verhindert, dass das `saving`-Event die manuell gesetzten
+Testwerte wieder überschreibt (Laravel-Standardmechanismus zum Umgehen von
+Model-Events für genau diesen Testfall).
+
+---
+
+## 3. HTML-Sanitizing — Wiederverwendung statt neuer Abhängigkeit
+
+**Geprüft (siehe Recherche):** `backend/composer.lock` enthält **keine**
+dedizierte HTML-Sanitizing-Bibliothek (`masterminds/html5` ist eine
+transitive Abhängigkeit von `barryvdh/laravel-dompdf` für die PDF-Erzeugung,
+nicht für Sanitizing nutzbar/vorgesehen). Das Projekt hat dieses Problem
+jedoch bereits für ein anderes Rich-Text-Feld gelöst:
+
+- `backend/app/Http/Requests/Concerns/SanitizesHtmlContent.php` — Trait mit
+  einer festen Tag-Allowlist (`p, br, strong, em, h2, h3, ul, ol, li,
+  blockquote, code, pre`) und zweistufiger Bereinigung (`strip_tags()` +
+  Attribut-Entfernung per Regex, entfernt damit auch
+  Event-Handler-Attribute wie `onclick` auf erlaubten Tags).
+- Verwendet von `StoreCourseRequest`/`UpdateCourseRequest` für das
+  Kurs-Beschreibungsfeld (`validatedSnakeCase()`,
+  `StoreCourseRequest.php:89-92`).
+- Der zugehörige clientseitige Editor `frontend/src/components/HtmlEditor.vue`
+  ist Tiptap-basiert (`@tiptap/vue-3`, `@tiptap/starter-kit`, bereits in
+  `frontend/package.json` vorhanden) und sanitized zusätzlich clientseitig
+  mit `dompurify` (ebenfalls bereits vorhanden).
+- Die Anzeige-Seite verwendet dieselbe Allowlist clientseitig erneut:
+  `frontend/src/views/courses/CoursesView.vue:319-325`
+  (`ALLOWED_TAGS`-Konstante, Kommentar *"consistent with the backend
+  sanitization allowlist"*).
+
+**Entscheidung:** `Announcement` verwendet exakt dasselbe Muster —
+`SanitizesHtmlContent`-Trait in `StoreAnnouncementRequest`/
+`UpdateAnnouncementRequest`, `HtmlEditor.vue` im Admin-Formular,
+`DOMPurify.sanitize()` mit derselben `ALLOWED_TAGS`-Konstante in
+`AnnouncementBanner.vue`. **Keine neue Composer- oder npm-Abhängigkeit.**
+Das erfüllt die CLAUDE.md-Vorgabe zur Prüfung vorhandener Bibliotheken vor
+Einführung einer neuen — hier ist keine neue nötig, weil eine
+funktional identische, bereits produktiv genutzte Lösung existiert
+(DRY: kein zweites Sanitizing-Muster für dasselbe Problem einführen).
+
+**Defense in depth:** Sanitizing findet **serverseitig** beim Speichern
+statt (nicht nur clientseitig im Editor) — ein Request direkt gegen die API
+(ohne den Editor zu durchlaufen) kann kein rohes HTML/JS einschleusen. Die
+clientseitige `DOMPurify`-Anwendung in `AnnouncementBanner.vue` beim
+Rendern ist eine zusätzliche Verteidigungsschicht, falls sich die
+Sanitizing-Regeln zwischen Backend und Frontend jemals unterscheiden
+sollten — genau das bereits etablierte Muster aus `CoursesView.vue`.
+
+---
+
+## 4. Backend — Policy, FormRequests, Resource
+
+### 4.1 `backend/app/Policies/AnnouncementPolicy.php` (neu)
+
+Identisch zu `backend/app/Policies/SettingPolicy.php` (alle Methoden
+`$user->isAdmin()`):
+
+```php
+class AnnouncementPolicy
+{
+    public function viewAny(User $user): bool { return $user->isAdmin(); }
+    public function view(User $user, Announcement $announcement): bool { return $user->isAdmin(); }
+    public function create(User $user): bool { return $user->isAdmin(); }
+    public function update(User $user, Announcement $announcement): bool { return $user->isAdmin(); }
+    public function delete(User $user, Announcement $announcement): bool { return $user->isAdmin(); }
+}
+```
+
+### 4.2 `backend/app/Http/Requests/StoreAnnouncementRequest.php` (neu)
+
+```php
+class StoreAnnouncementRequest extends FormRequest
+{
+    use SanitizesHtmlContent;
+
+    public function authorize(): bool
+    {
+        return $this->user()?->isAdmin() ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'body' => ['required', 'string', 'max:5000'],
+            'displayDays' => ['required', 'integer', 'min:1', 'max:365'],
+            'image' => ['nullable', 'image', 'mimes:jpg,jpeg,png,gif,webp', 'max:5120'],
+        ];
+    }
+
+    public function validatedSnakeCase(): array
+    {
+        $validated = $this->validated();
+
+        return [
+            'title' => $validated['title'],
+            'body' => $this->sanitizeHtmlDescription($validated['body']),
+            'display_days' => $validated['displayDays'],
+        ];
+    }
+}
+```
+
+`max:5000` für `body`: identisch zur bestehenden Grenze in
+`StoreCourseRequest.php:38` (Konsistenz statt einer neu erfundenen Zahl).
+`max:365` für `displayDays`: verhindert versehentliche De-facto-Dauerwerbung
+über Jahre (YAGNI — falls je eine längere Laufzeit gebraucht wird, ist das
+eine triviale, separate Änderung der Validierungsgrenze). `image`-Regeln
+identisch zu `DogController.php:185` (`mimes:jpg,jpeg,png,gif,webp|max:5120`).
+
+**Wichtig:** `image` wird bewusst **nicht** in `validatedSnakeCase()`
+zurückgegeben — der Controller behandelt den Datei-Upload separat (siehe
+4.4), analog zu `DogController::uploadImage()`. Nur `image_path` (der
+gespeicherte Pfad) landet in der DB, nie die `UploadedFile`-Instanz selbst.
+
+### 4.3 `backend/app/Http/Requests/UpdateAnnouncementRequest.php` (neu)
+
+Identisch zu 4.2, aber alle Felder mit `sometimes` (Teil-Updates erlaubt):
+
+```php
+public function rules(): array
+{
+    return [
+        'title' => ['sometimes', 'string', 'max:255'],
+        'body' => ['sometimes', 'string', 'max:5000'],
+        'displayDays' => ['sometimes', 'integer', 'min:1', 'max:365'],
+        'image' => ['nullable', 'image', 'mimes:jpg,jpeg,png,gif,webp', 'max:5120'],
+    ];
+}
+
+public function validatedSnakeCase(): array
+{
+    $validated = $this->validated();
+    $result = [];
+
+    if (array_key_exists('title', $validated)) {
+        $result['title'] = $validated['title'];
+    }
+    if (array_key_exists('body', $validated)) {
+        $result['body'] = $this->sanitizeHtmlDescription($validated['body']);
+    }
+    if (array_key_exists('displayDays', $validated)) {
+        $result['display_days'] = $validated['displayDays'];
+    }
+
+    return $result;
+}
+```
+
+### 4.4 `backend/app/Http/Resources/AnnouncementResource.php` (neu)
+
+**Dies ist der Übergabepunkt zwischen T05 (Backend) und T09 (Frontend).**
+Response-Shape (camelCase, Projektkonvention, siehe `DogResource.php`):
+
+```php
+class AnnouncementResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'body' => $this->body,
+            'imageUrl' => $this->image_path
+                ? Storage::disk('public')->url($this->image_path)
+                : null,
+            'displayDays' => $this->display_days,
+            'expiresAt' => $this->expires_at?->toISOString(),
+            'isActive' => $this->isActive(),
+            'createdAt' => $this->created_at?->toISOString(),
+            'updatedAt' => $this->updated_at?->toISOString(),
+        ];
+    }
+}
+```
+
+**Verbindliches JSON-Beispiel** (`GET /api/v1/announcements`,
+`GET /api/v1/admin/announcements`, sowie Response von `POST`/`PUT`):
+
+```json
+{
+  "data": [
+    {
+      "id": 3,
+      "title": "Kursausfall am 20.07.",
+      "body": "<p>Der Welpenkurs am 20.07. entfällt <strong>krankheitsbedingt</strong>.</p>",
+      "imageUrl": "https://example.test/storage/announcement-images/xyz.jpg",
+      "displayDays": 7,
+      "expiresAt": "2026-07-24T10:00:00.000000Z",
+      "isActive": true,
+      "createdAt": "2026-07-17T10:00:00.000000Z",
+      "updatedAt": "2026-07-17T10:00:00.000000Z"
+    }
+  ]
+}
+```
+
+Für Listen-Endpunkte immer `AnnouncementResource::collection(...)`
+(Laravel wrappt automatisch in `{"data": [...]}`), für Einzel-Antworten
+(`store`/`update`) `new AnnouncementResource($announcement)` (wrappt in
+`{"data": {...}}`).
+
+**Keine getrennte "öffentliche" vs. "Admin"-Resource nötig:** Im
+Unterschied zur ursprünglichen Vermutung in der Triage gibt es kein
+Admin-only-Feld, das vor Kunden verborgen werden müsste (kein `created_by`,
+keine internen Notizen) — `AnnouncementResource` wird für beide Endpunkte
+verwendet (YAGNI: keine zweite Resource-Klasse für identischen Output
+einführen).
+
+---
+
+## 5. Backend — Controller und Routen
+
+### 5.1 `backend/app/Http/Controllers/Api/AnnouncementController.php` (neu)
+
+Struktur folgt dem Autorisierungs-Muster von `DogController.php` (Policy
+über `$this->authorize()` für Aktionen mit vorhandener Modell-Instanz bzw.
+`viewAny`; `store` verlässt sich auf `StoreAnnouncementRequest::authorize()`
+allein, analog zu `DogController::store()`, das ebenfalls keinen
+zusätzlichen `$this->authorize()`-Aufruf hat):
+
+```php
+class AnnouncementController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function publicIndex(): AnonymousResourceCollection
+    {
+        $announcements = Announcement::query()
+            ->active()
+            ->orderByDesc('created_at')
+            ->get();
+
+        return AnnouncementResource::collection($announcements);
+    }
+
+    public function index(): AnonymousResourceCollection
+    {
+        $this->authorize('viewAny', Announcement::class);
+
+        return AnnouncementResource::collection(
+            Announcement::query()->orderByDesc('created_at')->get()
+        );
+    }
+
+    public function store(StoreAnnouncementRequest $request): JsonResponse
+    {
+        $data = $request->validatedSnakeCase();
+
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $this->storeImage($request);
+        }
+
+        $announcement = Announcement::create($data);
+
+        return (new AnnouncementResource($announcement))->response()->setStatusCode(201);
+    }
+
+    public function update(UpdateAnnouncementRequest $request, Announcement $announcement): AnnouncementResource
+    {
+        $this->authorize('update', $announcement);
+
+        $data = $request->validatedSnakeCase();
+
+        if ($request->hasFile('image')) {
+            if ($announcement->image_path && Storage::disk('public')->exists($announcement->image_path)) {
+                Storage::disk('public')->delete($announcement->image_path);
+            }
+            $data['image_path'] = $this->storeImage($request);
+        }
+
+        $announcement->update($data);
+
+        return new AnnouncementResource($announcement->fresh());
+    }
+
+    public function destroy(Announcement $announcement): JsonResponse
+    {
+        $this->authorize('delete', $announcement);
+
+        if ($announcement->image_path && Storage::disk('public')->exists($announcement->image_path)) {
+            Storage::disk('public')->delete($announcement->image_path);
+        }
+
+        $announcement->delete();
+
+        return response()->json(null, 204);
+    }
+
+    private function storeImage(Request $request): string
+    {
+        $file = $request->file('image');
+        $extension = strtolower($file->getClientOriginalExtension());
+        $filename = 'announcement_' . Str::uuid() . '.' . $extension;
+
+        return $file->storeAs('announcement-images', $filename, 'public');
+    }
+}
+```
+
+Datei-Speicherung identisch zum Muster in
+`DogController.php:196-197` (`Str::uuid()`-Dateiname,
+`Storage::disk('public')`, Alt-Bild-Löschung vor Ersetzung wie
+`DogController.php:192-193`).
+
+**Kein separater `update()`-Aufruf von `$request->hasFile('image')` in
+`store()` vs. `update()` unterschiedlich behandelt** — Logik ist bewusst
+identisch strukturiert (DRY), einziger Unterschied ist das Löschen des
+Alt-Bilds bei `update()`.
+
+### 5.2 Routen (`backend/routes/api.php`)
+
+**Import** (alphabetisch einsortiert, nach `AnamnesisTemplateController`,
+vor `AuthController`, Zeile 6-7):
+
+```php
+use App\Http\Controllers\Api\AnnouncementController;
+```
+
+**Öffentliche Route** — neuer Block direkt nach dem bestehenden
+"Public pricing route"-Block (`backend/routes/api.php:54-57`), vor dem
+"Public course detail route"-Block (Zeile 59):
+
+```php
+// Public announcements route (no auth required)
+Route::prefix('v1')->group(function () {
+    Route::get('/announcements', [AnnouncementController::class, 'publicIndex']);
+});
+```
+
+**Admin-Routen** — neuer Block innerhalb der bestehenden
+`auth:sanctum`-Gruppe, nach dem "Settings Management"-Block
+(`backend/routes/api.php:192-195`), vor der schließenden `});` der Gruppe
+(Zeile 197):
+
+```php
+// Announcement Management (Admin only)
+Route::middleware('can:admin')->group(function () {
+    Route::get('/admin/announcements', [AnnouncementController::class, 'index']);
+    Route::post('/admin/announcements', [AnnouncementController::class, 'store']);
+    Route::put('/admin/announcements/{announcement}', [AnnouncementController::class, 'update']);
+    Route::delete('/admin/announcements/{announcement}', [AnnouncementController::class, 'destroy']);
+});
+```
+
+**Wichtig — Multipart + `PUT` (Shared-Hosting-Präzedenzfall):** Die Route
+ist als `PUT` definiert (Laravel-Konvention, RESTful), der tatsächliche
+HTTP-Request beim Bearbeiten mit Bild-Austausch wird aber — wie bei
+`settingsApi.updateSettings()` — als `POST` mit `_method=PUT`-Override-Feld
+gesendet (siehe Abschnitt 6.1). **Grund:** Bereits einmal produktiv
+aufgetreten und behoben
+(`openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/`):
+PHP befüllt `$_FILES` bei einem echten `multipart/form-data`-`PUT`-Request
+nicht zuverlässig plattform-/PHP-Versions-unabhängig. Laravels
+`enableHttpMethodParameterOverride()` löst das Method-Override aus `_method`
+aber bereits vor dem Routing auf, sodass die Route selbst unverändert `PUT`
+bleiben kann.
+
+---
+
+## 6. Frontend — API-Client und Composable
+
+### 6.1 `frontend/src/api/announcements.ts` (neu)
+
+Folgt `frontend/src/api/pricingItems.ts` für die Grundstruktur, aber
+`create`/`update` senden `FormData` statt JSON (Bild-Upload), und `update`
+übernimmt exakt das `_method=PUT`-Override-Muster aus
+`frontend/src/api/settings.ts:35-58` (siehe Abschnitt 5.2).
+
+**Korrektur nach Skeptiker-Prüfung (verifiziert):** `apiClient`
+(`frontend/src/api/client.ts:33-40`) setzt auf der Axios-Instanz einen
+festen Default-Header `'Content-Type': 'application/json'`. Wird dieser
+Default nicht pro Request überschrieben, serialisiert Axios ein
+`FormData`-Objekt **nicht** automatisch als
+`multipart/form-data` — der Upload (und beim `update`-Call auch das
+`_method=PUT`-Override-Feld) würde fehlschlagen. Beide bestehenden
+FormData-Upload-Stellen im Projekt setzen deshalb explizit
+`headers: { 'Content-Type': 'multipart/form-data' }` pro Request:
+`frontend/src/api/settings.ts:60-64` und
+`frontend/src/api/trainingAttachments.ts:54-58`. Der folgende Code
+übernimmt diesen Header-Override für **beide** Methoden (`create` **und**
+`update`, nicht nur `update` — auch `create` sendet `FormData` und war im
+ursprünglichen Entwurf ohne den Override fehlerhaft):
+
+```ts
+export interface Announcement {
+  id: number
+  title: string
+  body: string
+  imageUrl: string | null
+  displayDays: number
+  expiresAt: string | null
+  isActive: boolean
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+export interface AnnouncementFormData {
+  title: string
+  body: string
+  displayDays: number
+  image?: File | null
+}
+
+function buildFormData(data: Partial<AnnouncementFormData>): FormData {
+  const formData = new FormData()
+  if (data.title !== undefined) formData.append('title', data.title)
+  if (data.body !== undefined) formData.append('body', data.body)
+  if (data.displayDays !== undefined) formData.append('displayDays', String(data.displayDays))
+  if (data.image) formData.append('image', data.image)
+  return formData
+}
+
+export const announcementsApi = {
+  async getPublic(): Promise<Announcement[]> {
+    const response = await apiClient.get<{ data: Announcement[] }>('/api/v1/announcements')
+    return response.data.data
+  },
+  async getAll(): Promise<Announcement[]> {
+    const response = await apiClient.get<{ data: Announcement[] }>('/api/v1/admin/announcements')
+    return response.data.data
+  },
+  async create(data: AnnouncementFormData): Promise<Announcement> {
+    const response = await apiClient.post<{ data: Announcement }>(
+      '/api/v1/admin/announcements',
+      buildFormData(data),
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    )
+    return response.data.data
+  },
+  async update(id: number, data: Partial<AnnouncementFormData>): Promise<Announcement> {
+    const formData = buildFormData(data)
+    formData.set('_method', 'PUT')
+    const response = await apiClient.post<{ data: Announcement }>(
+      `/api/v1/admin/announcements/${id}`,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    )
+    return response.data.data
+  },
+  async delete(id: number): Promise<void> {
+    await apiClient.delete(`/api/v1/admin/announcements/${id}`)
+  },
+}
+```
+
+### 6.2 `frontend/src/composables/useAnnouncements.ts` (neu)
+
+Folgt `frontend/src/composables/usePricingItems.ts` 1:1 im Aufbau
+(`ref`-State, `loading`/`error`, `loadPublic`/`loadAll`/`createAnnouncement`/
+`updateAnnouncement`/`deleteAnnouncement`, jeweils mit try/catch und
+deutschsprachiger Fehlermeldung).
+
+---
+
+## 7. Frontend — öffentliche Anzeige
+
+### 7.1 `frontend/src/components/AnnouncementBanner.vue` (neu)
+
+- Lädt beim Mount über `useAnnouncements().loadPublic()`.
+- `v-if="announcements.length"` auf der äußeren `<section>` — kein Rendern,
+  wenn keine aktive Ankündigung existiert (Kernanforderung der Triage).
+- **Layout-Entscheidung (User hat Detail dem Architekten überlassen):**
+  einfache vertikal gestapelte Liste (`v-for`), **kein** Karussell/Slider.
+  Begründung (KISS): Ein Slider bräuchte zusätzliche
+  State-Verwaltung/Timer-Logik und ggf. eine neue Bibliothek, für eine in
+  der Praxis meist einstellige Anzahl gleichzeitig aktiver Ankündigungen
+  nicht gerechtfertigt (YAGNI). Jede Ankündigung ist eine eigene Karte mit
+  optionalem Bild links, Titel + Rich-Text rechts (analog zum bestehenden
+  Karten-Layout der Feature-Section, konsistentes Look-and-Feel).
+- HTML-Ausgabe: `v-html="sanitizeHtml(announcement.body)"` mit **derselben**
+  `ALLOWED_TAGS`-Konstante wie `CoursesView.vue:320`
+  (`p, br, strong, em, h2, h3, ul, ol, li, blockquote, code, pre`), inkl.
+  `<!-- eslint-disable-next-line vue/no-v-html -->`-Kommentar (bestehende
+  Projektkonvention für alle `v-html`-Stellen).
+
+### 7.2 `frontend/src/views/HomeView.vue` (ändern)
+
+Neue Zeile zwischen dem schließenden `</section>` der Hero-Section
+(Zeile 26) und dem Kommentar `<!-- Features Section -->` (Zeile 28/29):
+
+```html
+    <AnnouncementBanner />
+```
+
+Import im `<script setup>`-Block (nach den bestehenden Imports,
+Zeile 205/206):
+
+```ts
+import AnnouncementBanner from '@/components/AnnouncementBanner.vue'
+```
+
+**Kein zusätzlicher `onMounted()`-Aufruf in `HomeView.vue` nötig** — die
+Komponente lädt ihre Daten selbst beim eigenen Mount (Kapselung, analog zu
+`PricingModal`, das ebenfalls seine eigenen Daten über
+`usePricingItems()` lädt, siehe Zeile 209/217 — dort wird `loadPublic()`
+zwar in `HomeView.vue` aufgerufen, weil die Preisdaten auch für das
+`PricingModal`-Prop `groups` gebraucht werden; `AnnouncementBanner`
+dagegen hat keine Eltern-Abhängigkeit auf die geladenen Daten, kapselt sie
+also selbst — DRY/Separation of Concerns).
+
+---
+
+## 8. Frontend — Admin-Bereich
+
+### 8.1 `frontend/src/views/AnnouncementsView.vue` (neu)
+
+Nächstliegendes Vorbild: `frontend/src/views/SettingsView.vue`
+("Admin bearbeitet globale Inhalte"-Seite, laut Triage-Codebasis-Befund).
+Struktur:
+
+- Liste **aller** Ankündigungen (`useAnnouncements().loadAll()`),
+  **inklusive abgelaufener** (Kernanforderung Punkt 5), je Eintrag:
+  - Status-Badge: grün "Aktiv" wenn `announcement.isActive === true`,
+    grau "Abgelaufen" sonst.
+  - Titel, gekürzte Textvorschau, Miniaturbild falls vorhanden,
+    Anzeigedauer, Ablaufdatum (`expiresAt`, formatiert).
+  - Bearbeiten-Button (öffnet Formular vorausgefüllt) und
+    Löschen-Button (mit Bestätigungsdialog, analog bestehender
+    Lösch-Bestätigungen im Projekt, z. B. `PricingItemForm.vue`, falls
+    dort vorhanden — sonst einfaches `confirm()`/Toast-Muster wie in
+    `CoursesView.vue`).
+- Formular (Create/Edit), eingebettet oder als Modal (Detailentscheidung
+  liegt beim `dev-typescript`-Agenten, orientiert an
+  `PricingItemForm.vue`/`DogFormModal.vue` je nachdem, was für die
+  Seitengröße angemessener ist — beide Muster existieren im Projekt):
+  - Textfeld `title` (`<input type="text">`, `maxlength="255"`).
+  - `<HtmlEditor v-model="form.body" />` (bestehende Komponente,
+    Abschnitt 3).
+  - `<FileUpload :multiple="false" accepted-types="image/*" @upload="..." />`
+    (bestehende Komponente, `multiple=false` deckt Kernanforderung
+    Punkt 3 — genau ein Bild — bereits auf Komponentenebene ab).
+  - Zahlenfeld `displayDays` (`<input type="number" min="1" max="365">`).
+  - Speichern ruft `createAnnouncement`/`updateAnnouncement` auf; beim
+    Bearbeiten mit neuem Bild wird `image` im Payload gesetzt, sonst
+    weggelassen (bestehendes Bild bleibt unverändert — **kein**
+    "Bild entfernen"-Schalter in diesem Change, YAGNI, nicht angefordert).
+
+### 8.2 `frontend/src/router/index.ts` (ändern)
+
+Neuer Eintrag im `/app`-Kind-Routen-Array, nach dem `settings`-Eintrag
+(Zeile 127-131), vor `training-logs` (Zeile 133):
+
+```ts
+{
+  path: 'announcements',
+  name: 'Announcements',
+  component: () => import('@/views/AnnouncementsView.vue'),
+  meta: { title: 'Ankündigungen', requiresAdmin: true }
+},
+```
+
+Folgt exakt dem bestehenden `Settings`-Eintrag-Muster (lazy import,
+`requiresAdmin: true`, ausgewertet vom bestehenden Router-Guard
+`frontend/src/router/index.ts:181-185`).
+
+### 8.3 `frontend/src/layouts/DefaultLayout.vue` (ändern)
+
+Neuer Navigations-Eintrag im `navigation`-Computed
+(nach dem `Einstellungen`-Eintrag, Zeile 227-232, vor `Kontakt`,
+Zeile 233-238):
+
+```ts
+{
+  name: 'Ankündigungen',
+  to: { name: 'Announcements' },
+  icon: MegaphoneIcon,
+  roles: ['admin']
+},
+```
+
+`MegaphoneIcon`-Import ergänzen in der bestehenden
+`@heroicons/vue/24/outline`-Import-Liste (Zeile 110-126); verifiziert
+vorhanden unter
+`frontend/node_modules/@heroicons/vue/24/outline/MegaphoneIcon.js`.
+
+---
+
+## 9. Übersicht neuer/geänderter Dateien
+
+### Backend
+
+| Datei | Status | Task |
+|---|---|---|
+| `backend/database/migrations/2026_07_17_100000_create_announcements_table.php` | neu | T01 |
+| `backend/app/Models/Announcement.php` | neu | T02 |
+| `backend/database/factories/AnnouncementFactory.php` | neu | T02 |
+| `backend/app/Policies/AnnouncementPolicy.php` | neu | T03 |
+| `backend/app/Http/Requests/StoreAnnouncementRequest.php` | neu | T04 |
+| `backend/app/Http/Requests/UpdateAnnouncementRequest.php` | neu | T04 |
+| `backend/app/Http/Resources/AnnouncementResource.php` | neu | T05 |
+| `backend/app/Http/Controllers/Api/AnnouncementController.php` | neu | T06 |
+| `backend/routes/api.php` | ändern | T07 |
+| `backend/tests/Feature/Api/AnnouncementApiTest.php` | neu | T08 |
+
+### Frontend
+
+| Datei | Status | Task |
+|---|---|---|
+| `frontend/src/api/announcements.ts` | neu | T09 |
+| `frontend/src/api/announcements.test.ts` | neu | T09 |
+| `frontend/src/composables/useAnnouncements.ts` | neu | T09 |
+| `frontend/src/components/AnnouncementBanner.vue` | neu | T10 |
+| `frontend/src/components/AnnouncementBanner.test.ts` | neu | T10 |
+| `frontend/src/views/HomeView.vue` | ändern | T10 |
+| `frontend/src/views/AnnouncementsView.vue` | neu | T11 |
+| `frontend/src/views/AnnouncementsView.test.ts` | neu | T11 |
+| `frontend/src/router/index.ts` | ändern | T11 |
+| `frontend/src/layouts/DefaultLayout.vue` | ändern | T11 |
+
+---
+
+## 10. Shared-Hosting-Kompatibilität (CLAUDE.md Abschnitt 3/4)
+
+| Aspekt | Bewertung |
+|---|---|
+| PHP 8.2 | Zu prüfen (kein automatisiertes `compat-check`-Script vorhanden, siehe `proposal.md` "Out of Scope"): geplanter Code verwendet nur Standard-Eloquent, Enums/Attribute aus 8.3/8.4 werden nicht benötigt und dürfen von `dev-php` nicht eingesetzt werden |
+| MySQL + PostgreSQL | ✓ — Migration nur `string()`/`text()`/`unsignedSmallInteger()`/`timestamp()`/`timestamps()`/`index()`, kein raw SQL (Abschnitt 2.2) |
+| Kein Queue-Worker/Scheduler | ✓ — Ablauf wird beim Lesen berechnet (`scopeActive()`), keine Hintergrundverarbeitung (Abschnitt 2.1) |
+| Kein Shell-Exec | ✓ — reine Eloquent-/Validierungs-/Storage-Facade-Operationen |
+| Datei-Upload | ✓ — `Storage::disk('public')`, bestehende `.htaccess`-Limits (10 MB) decken `max:5120` (5 MB) bereits ab, keine Deployment-Template-Änderung nötig |
+| Build-Artefakte | ✓ — keine neue npm-/Composer-Abhängigkeit, bestehender Vite-Build deckt `AnnouncementBanner.vue`/`AnnouncementsView.vue` ab |
+
+---
+
+## 11. Risiken
+
+| Risiko | Bewertung / Gegenmaßnahme |
+|---|---|
+| Admin erstellt sehr viele gleichzeitig aktive Ankündigungen, Landingpage wird unübersichtlich lang | Bewusst nicht technisch begrenzt (siehe `proposal.md` "Out of Scope") — redaktionelle Verantwortung, kein angefordertes Akzeptanzkriterium für eine Obergrenze (YAGNI) |
+| `expires_at` wird beim Bearbeiten einer Ankündigung nur neu berechnet, wenn `display_days` sich ändert — Admin ändert nur den Text und erwartet fälschlich eine Verlängerung | Dokumentiertes Verhalten (Abschnitt 2.3): Textänderungen verlängern die Anzeige **nicht** automatisch; dies entspricht der Nutzerentscheidung ("anzeigeseitig berechnet aus `display_days`"), nicht "jede Bearbeitung verlängert automatisch". Sollte sich das als unerwünscht herausstellen, ist eine spätere separate Änderung (expliziter "Anzeigedauer verlängern"-Button) trivial nachrüstbar |
+| Zwei Sanitizing-Allowlists (Backend-Trait, Frontend-Konstante) könnten auseinanderlaufen, falls künftig eine Stelle geändert wird, die andere nicht | Vorbestehendes Risiko, nicht neu durch diesen Change eingeführt (`CoursesView.vue` hat dasselbe Muster bereits); der bestehende Code-Kommentar *"consistent with the backend sanitization allowlist"* wird im neuen Frontend-Code wortgleich übernommen, um die Kopplung sichtbar zu halten |

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/proposal.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/proposal.md
@@ -1,0 +1,156 @@
+# Proposal: add-announcement-banner
+
+**Change-ID:** add-announcement-banner
+**Typ:** Feature (additiv, kein Breaking Change)
+**Priorität:** mittel
+**Datum:** 2026-07-17
+**Triage:** `openspec/triage/20260717103000-announcement-banner.md`
+
+---
+
+## Why
+
+Die Hundeschule hat aktuell keine Möglichkeit, kurzfristige Mitteilungen
+(z. B. Kursausfälle, neue Angebote, Betriebsferien) prominent auf der
+öffentlichen Landingpage zu kommunizieren, ohne den festen Seiteninhalt in
+`HomeView.vue` zu bearbeiten. Admins brauchen einen einfachen Weg, um
+zeitlich befristete Ankündigungen mit Bild zu veröffentlichen, die nach
+einer festgelegten Anzahl Tage automatisch nicht mehr angezeigt werden —
+ohne dass dafür ein Server-Scheduler oder manuelles Löschen nötig ist
+(Shared-Hosting-Einschränkung, siehe `CLAUDE.md` Abschnitt 4.3).
+
+## What Changes
+
+- Neues Datenmodell `Announcement` (Tabelle `announcements`): Titel,
+  Rich-Text-Inhalt (HTML, serverseitig sanitized), optionales Bild,
+  Anzeigedauer in Tagen. Der Ablauf wird **anzeigeseitig berechnet**
+  (`expires_at`, aus `created_at` + `display_days` beim Speichern
+  vorausberechnet) — kein Cron-/Scheduler-Task nötig.
+- Öffentlicher Endpunkt `GET /api/v1/announcements` liefert **alle aktuell
+  aktiven** Ankündigungen als Liste (mehrere gleichzeitig aktive
+  Ankündigungen sind laut Nutzerentscheidung ausdrücklich erlaubt).
+- Neue öffentliche Komponente `AnnouncementBanner.vue`, eingebunden in
+  `HomeView.vue` zwischen der Hero-Section (endet Zeile 26) und der
+  Feature-Section "Unsere Leistungen" (beginnt Zeile 29). Bedingtes
+  Rendering: Der Bereich erscheint nur, wenn mindestens eine aktive
+  Ankündigung existiert.
+- Neuer Admin-Bereich (`AnnouncementsView.vue`, Route `/app/announcements`,
+  `requiresAdmin: true`) zum Erstellen/Bearbeiten/Löschen von
+  Ankündigungen. Der Rich-Text wird über die bereits im Projekt vorhandene
+  `HtmlEditor.vue`-Komponente (Tiptap-basiert) erfasst, das Bild über die
+  bereits vorhandene `FileUpload.vue`-Komponente (`multiple=false`)
+  hochgeladen. Die Admin-Liste zeigt **auch abgelaufene** Ankündigungen mit
+  einem Status-Badge ("aktiv"/"abgelaufen") — es wird nichts automatisch
+  gelöscht.
+- Serverseitiges HTML-Sanitizing beim Speichern über den bereits
+  bestehenden Trait `App\Http\Requests\Concerns\SanitizesHtmlContent`
+  (aktuell verwendet von `StoreCourseRequest`/`UpdateCourseRequest` für das
+  Kurs-Beschreibungsfeld) — **keine neue Composer-Abhängigkeit nötig**, da
+  dieser Mechanismus bereits im Projekt etabliert ist und exakt zum
+  clientseitigen Tiptap/DOMPurify-Editor passt, den `HtmlEditor.vue` bereits
+  verwendet.
+
+## Capabilities
+
+### New Capabilities
+
+- `announcement-management`: Erstellung, Sanitizing, Speicherung, zeitlich
+  befristete öffentliche Anzeige und admin-seitige Verwaltung (inkl.
+  Historie abgelaufener Einträge) von Ankündigungen mit Bild und
+  Rich-Text-Inhalt.
+
+### Modified Capabilities
+
+*(keine — es gibt aktuell keine dokumentierte Capability für die
+Landingpage-Struktur (`HomeView.vue`) oder das Admin-Navigationsmenü
+(`DefaultLayout.vue`), deren bestehendes Verhalten durch dieses Feature
+geändert würde; beide Änderungen sind rein additiv — ein neuer,
+bedingt sichtbarer Abschnitt bzw. ein neuer Menüpunkt, kein bestehendes
+Verhalten wird entfernt oder umdefiniert.)*
+
+## Impact
+
+**Betroffene Dateien (siehe `design.md` für Details und Task-Zuordnung):**
+
+- Backend (neu): Migration `create_announcements_table`, Model
+  `Announcement` (+ Factory), Policy `AnnouncementPolicy`, FormRequests
+  `StoreAnnouncementRequest`/`UpdateAnnouncementRequest`, Resource
+  `AnnouncementResource`, Controller `Api/AnnouncementController`,
+  Routen-Ergänzung in `backend/routes/api.php`, Feature-Test
+  `tests/Feature/Api/AnnouncementApiTest.php`.
+- Frontend (neu): `frontend/src/api/announcements.ts`,
+  `frontend/src/composables/useAnnouncements.ts`,
+  `frontend/src/components/AnnouncementBanner.vue`,
+  `frontend/src/views/AnnouncementsView.vue`, zugehörige Vitest-Tests.
+- Frontend (ändern): `frontend/src/views/HomeView.vue` (neue Sektion
+  zwischen Zeile 26/29), `frontend/src/router/index.ts` (neue Route),
+  `frontend/src/layouts/DefaultLayout.vue` (neuer Navigationspunkt für
+  Admins).
+
+**Keine betroffenen Drittsysteme, keine Queue-/Scheduler-Änderungen, kein
+Shell-Exec, keine WebSockets.** Kein neues npm- oder Composer-Paket
+erforderlich (Rich-Text-Editor, HTML-Sanitizing client- und serverseitig
+sind bereits im Projekt vorhanden, siehe `design.md` Abschnitt 3).
+
+**DB-Portabilität:** Die neue Migration verwendet ausschließlich
+`Schema::create()` mit treiberneutralen Blueprint-Typen (`string`, `text`,
+`unsignedSmallInteger`, `timestamp`, `timestamps`) — kein raw SQL, kein
+Driver-Switch nötig (siehe `design.md` Abschnitt 2).
+
+**Datei-Upload:** folgt dem etablierten `Storage::disk('public')`-Muster
+(`backend/app/Http/Controllers/Api/DogController.php:192-199`) — Bilder
+werden im bereits per `storage:link` öffentlich verlinkten Verzeichnis
+abgelegt, keine neuen Shared-Hosting-Anforderungen. Die bestehenden
+`.htaccess`-Body-Size-Limits (`LimitRequestBody 10485760`,
+`upload_max_filesize 10M`) decken die geplante Laravel-Validierungsgrenze
+von `max:5120` (5 MB, identisch zu `DogController`) bereits ab — keine
+Änderung an `deployment-templates/htaccess/backend-public.htaccess`
+nötig.
+
+## Out of Scope
+
+- Kein Scheduler-/Cron-Task zum "Aufräumen" abgelaufener Ankündigungen —
+  laut Nutzerentscheidung wird der Ablauf ausschließlich anzeigeseitig
+  berechnet, abgelaufene Einträge bleiben in der DB und im Admin-Bereich
+  sichtbar (Status-Badge), bis ein Admin sie manuell löscht.
+- Kein manueller "jetzt veröffentlichen/sofort deaktivieren"-Schalter —
+  nicht angefordert; die Anzeigedauer in Tagen ab Erstellung ist die
+  einzige Steuerungsgröße (YAGNI).
+- Keine Galerie/Mehrfachbilder pro Ankündigung — laut Nutzerentscheidung
+  genau ein Bild pro Ankündigung.
+- Kein Karussell/Slider für mehrere gleichzeitig aktive Ankündigungen —
+  `design.md` legt eine einfache vertikal gestapelte Liste fest (KISS,
+  keine zusätzliche JS-Abhängigkeit für einen Slider).
+- Keine Begrenzung der Anzahl gleichzeitig aktiver Ankündigungen auf der
+  Landingpage — laut Nutzerentscheidung sind mehrere gleichzeitig aktive
+  Ankündigungen ausdrücklich erwünscht; eine Obergrenze wurde nicht
+  angefordert (liegt in der redaktionellen Verantwortung der Admins).
+- Keine neue Composer-/npm-Abhängigkeit für Rich-Text oder HTML-Sanitizing
+  — bestehende Mechanismen (`SanitizesHtmlContent`-Trait, `HtmlEditor.vue`,
+  `dompurify`) werden wiederverwendet (siehe `design.md` Abschnitt 3).
+- **Fehlende QA-Scripts (bereits im Vorgänger-Change
+  `add-dog-owner-history-fields` festgestellt, weiterhin unverändert):**
+  `backend/composer.json` enthält aktuell **keine** Scripts `test`, `lint`,
+  `stan`, `qa` oder `compat-check` (geprüft, Stand 2026-07-17); `frontend/
+  package.json` enthält **kein** `lint`-Script. Die tatsächlich
+  verfügbaren Befehle sind `./vendor/bin/pest` (Backend) und `npm run
+  test` / `npm run build` (Frontend). Die Akzeptanzkriterien in
+  `tasks.md` referenzieren daher nur tatsächlich existierende Befehle.
+  Das Einrichten der in `CLAUDE.md` referenzierten QA-Scripts bleibt ein
+  eigenständiges, separates Vorhaben.
+
+## Referenzen
+
+- Triage: `openspec/triage/20260717103000-announcement-banner.md`
+- Neue Capability `announcement-management` (siehe
+  `specs/announcement-management/spec.md`)
+- Bestehendes Sanitizing-Muster: `backend/app/Http/Requests/Concerns/SanitizesHtmlContent.php`,
+  verwendet von `backend/app/Http/Requests/StoreCourseRequest.php:89-92`
+- Bestehender Rich-Text-Editor: `frontend/src/components/HtmlEditor.vue`
+- Bestehendes Anzeige-Sanitizing-Muster: `frontend/src/views/courses/CoursesView.vue:319-325`
+  (`ALLOWED_TAGS`-Konstante + `DOMPurify.sanitize()`, "consistent with the
+  backend sanitization allowlist")
+- Bestehendes Upload-Muster: `backend/app/Http/Controllers/Api/DogController.php:180-202`
+- Bestehendes Multipart-PUT-Muster (Fix-Präzedenzfall):
+  `openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/`,
+  umgesetzt in `frontend/src/api/settings.ts:35-58`

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/specs/announcement-management/spec.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/specs/announcement-management/spec.md
@@ -1,0 +1,156 @@
+# Spec Delta: Announcement Management
+
+**Change:** add-announcement-banner
+**Capability:** announcement-management (neu)
+
+---
+
+## ADDED Requirements
+
+### Requirement: Admins can create announcements with rich text, an optional image, and a display duration
+
+The system SHALL allow an authenticated user with the `admin` role to create
+an announcement consisting of a `title`, a rich-text `body` (HTML,
+server-side sanitized), an optional single image, and a `displayDays` value
+(integer, 1–365) that determines how long the announcement remains active.
+
+Non-admin users (including unauthenticated requests) SHALL NOT be able to
+create, update, or delete announcements.
+
+#### Scenario: Admin creates an announcement with all fields
+- **WHEN** an admin submits `POST /api/v1/admin/announcements` with
+  `title`, `body`, `displayDays`, and an image file
+- **THEN** the system SHALL persist the announcement
+- **AND** the response SHALL include `imageUrl` pointing to the stored
+  image on the `public` disk
+
+#### Scenario: Admin creates an announcement without an image
+- **WHEN** an admin submits `POST /api/v1/admin/announcements` with
+  `title`, `body`, and `displayDays`, but no image
+- **THEN** the system SHALL create the announcement successfully
+- **AND** `imageUrl` SHALL be `null` in the response
+
+#### Scenario: Non-admin is rejected
+- **WHEN** a non-admin (or unauthenticated) request attempts
+  `POST /api/v1/admin/announcements`, `PUT
+  /api/v1/admin/announcements/{id}`, or
+  `DELETE /api/v1/admin/announcements/{id}`
+- **THEN** the system SHALL respond with HTTP 403 (or 401 if unauthenticated)
+- **AND** SHALL NOT persist any change
+
+#### Scenario: Invalid display duration is rejected
+- **WHEN** a request to create or update an announcement includes a
+  `displayDays` value outside the range 1–365
+- **THEN** the system SHALL respond with HTTP 422
+- **AND** SHALL NOT persist the invalid value
+
+---
+
+### Requirement: Announcement body HTML is sanitized server-side before storage
+
+The system SHALL strip any HTML tags and attributes not on the project's
+established rich-text allowlist (`p, br, strong, em, h2, h3, ul, ol, li,
+blockquote, code, pre`, no attributes) from the `body` field before
+persisting an announcement, regardless of what the client sends.
+
+#### Scenario: Disallowed tags and event-handler attributes are removed
+- **WHEN** an admin submits a `body` value containing `<script>` tags or an
+  `onclick` attribute on an otherwise-allowed tag (e.g.
+  `<strong onclick="...">`)
+- **THEN** the system SHALL store the value with the disallowed tag
+  removed and all attributes stripped from the remaining allowed tags
+- **AND** SHALL NOT execute or persist the injected script/attribute
+
+#### Scenario: Allowed formatting is preserved
+- **WHEN** an admin submits a `body` value using only allowed tags (e.g.
+  `<p>`, `<strong>`, `<ul><li>`)
+- **THEN** the system SHALL persist the formatting unchanged (aside from
+  attribute stripping)
+
+---
+
+### Requirement: Multiple announcements can be active at the same time
+
+The system SHALL support more than one announcement being active
+simultaneously. There SHALL be no mechanism that deactivates or hides one
+active announcement when another is created or becomes active.
+
+#### Scenario: Two announcements are active at once
+- **WHEN** two announcements exist whose display windows both currently
+  cover `now()`
+- **THEN** the public endpoint SHALL return both in its response list
+
+---
+
+### Requirement: Announcement expiry is computed from the display duration without a scheduler
+
+The system SHALL determine whether an announcement is currently active by
+comparing a persisted `expiresAt` timestamp (computed from the
+announcement's original creation time plus `displayDays`) against the
+current time at read time. No scheduled task, cron job, or queue worker
+SHALL be required to deactivate an expired announcement.
+
+#### Scenario: Announcement becomes inactive after its display duration elapses
+- **WHEN** an announcement was created with `displayDays = 3` and more
+  than 3 days have since passed
+- **THEN** the public endpoint (`GET /api/v1/announcements`) SHALL NOT
+  include this announcement in its response
+- **AND** no scheduled job needs to run for this to take effect
+
+#### Scenario: Editing an announcement's text does not silently extend its display window
+- **WHEN** an admin updates only the `title` or `body` of an existing
+  announcement, without changing `displayDays`
+- **THEN** the announcement's `expiresAt` SHALL remain based on its
+  original creation time, not the edit time
+
+#### Scenario: Changing displayDays recalculates the expiry from the original creation time
+- **WHEN** an admin updates `displayDays` on an existing, not-yet-expired
+  announcement
+- **THEN** the system SHALL recompute `expiresAt` as the announcement's
+  original `createdAt` plus the new `displayDays` value (not from the
+  edit time)
+
+---
+
+### Requirement: Public landing page displays only currently active announcements
+
+The system SHALL expose a public, unauthenticated endpoint
+(`GET /api/v1/announcements`) that returns only announcements that are
+currently active. The public landing page (`HomeView.vue`) SHALL render an
+announcement section between the hero section and the "Unsere
+Leistungen" feature section only when at least one active announcement
+exists; otherwise the section SHALL NOT be rendered.
+
+#### Scenario: No active announcements exist
+- **WHEN** no announcement is currently active
+- **THEN** `GET /api/v1/announcements` SHALL return an empty list
+- **AND** the landing page SHALL NOT render the announcement section
+
+#### Scenario: At least one active announcement exists
+- **WHEN** at least one announcement is currently active
+- **THEN** the landing page SHALL render the announcement section between
+  the hero section and the "Unsere Leistungen" section
+- **AND** each active announcement SHALL be displayed with its
+  sanitized rich-text body and image (if present)
+
+---
+
+### Requirement: Admin area lists all announcements including expired ones, with a status indicator
+
+The system SHALL provide an admin-only view that lists **all**
+announcements — both currently active and expired — without automatically
+deleting expired ones. Each entry SHALL be labeled with its current status
+(active or expired).
+
+#### Scenario: Admin views the announcement list
+- **WHEN** an admin navigates to the announcement management area
+- **THEN** the system SHALL display all announcements, each with a status
+  label of "active" or "expired" matching whether `expiresAt` is in the
+  future or the past
+- **AND** expired announcements SHALL remain visible and editable/deletable,
+  not hidden or auto-removed
+
+#### Scenario: Admin deletes an announcement
+- **WHEN** an admin deletes an announcement that has an associated image
+- **THEN** the system SHALL remove the announcement record
+- **AND** SHALL delete the associated image file from storage

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T01.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T01.notes.md
@@ -1,0 +1,112 @@
+# Notes: T01 — Migration `create_announcements_table`
+
+**Agent:** dev-php
+**Status:** abgeschlossen
+
+## Umgesetzt
+
+- `backend/database/migrations/2026_07_17_100000_create_announcements_table.php`
+  (neu), Schema exakt wie in `tasks.md`/`design.md` Abschnitt 2.2 vorgegeben:
+  `id`, `title` (string, 255), `body` (text), `image_path` (string, nullable),
+  `display_days` (unsignedSmallInteger), `expires_at` (timestamp, **nicht**
+  nullable — siehe Begründung in `design.md` Abschnitt 2.2), `timestamps()`,
+  Index auf `expires_at`. `down()`: `Schema::dropIfExists('announcements')`.
+- Stil an den zuletzt hinzugefügten Migrationen orientiert (z. B.
+  `backend/database/migrations/2026_07_16_120000_add_owner_history_to_dogs_table.php`,
+  `2026_05_14_000001_create_pricing_items_table.php`): kein
+  `declare(strict_types=1);` — in `backend/database/migrations/` verwenden nur
+  9 von 41 bestehenden Dateien diese Deklaration, alle jüngeren (2026er)
+  Migrationen verzichten darauf; CLAUDE.md Abschnitt 6 fordert
+  `strict_types` explizit nur für neue Dateien in `backend/app/`, nicht für
+  Migrationen. Deshalb dem etablierten, aktuelleren Muster gefolgt statt der
+  Minderheitskonvention.
+
+## Ausschließlich treiberneutrale Blueprint-Methoden
+
+Verwendet: `id()`, `string()`, `text()`, `nullable()`, `unsignedSmallInteger()`,
+`timestamp()`, `timestamps()`, `index()`. Kein `DB::raw()`, kein
+`DB::statement()`, keine Postgres-/MySQL-spezifischen Typen oder Operatoren
+(CLAUDE.md Abschnitt 4.2).
+
+## PHP-Kompatibilität (CLAUDE.md Abschnitt 4.1)
+
+Manuell geprüft (kein `compat-check`-Script im Projekt vorhanden, siehe
+`verification.md` Zeile 47-49 sowie `proposal.md` "Out of Scope"): keine
+Property Hooks, keine Asymmetric Visibility, kein `#[\Deprecated]`, keine
+PHP-8.4-`array_*`-Funktionen, kein `new MyClass()->method()`, keine Lazy
+Objects; keine Typed Class Constants, kein `#[\Override]`, kein
+`json_validate()`, kein Dynamic Class Constant Fetch, keine
+`Randomizer`-8.3-Methoden. Die Datei nutzt ausschließlich seit PHP 8.1/8.2
+verfügbare Standard-Laravel-Migrations-Syntax.
+
+## Lokale Tests (Docker, siehe CLAUDE.md Abschnitt 5/7.1)
+
+**PostgreSQL (lokale Docker-Standardumgebung, `docker-compose.yml`):**
+- `docker compose up -d postgres php`
+- `php artisan migrate` → `2026_07_17_100000_create_announcements_table` lief
+  fehlerfrei durch (zusammen mit anderen zuvor bereits ausstehenden
+  Migrationen der Entwicklungs-DB, die nicht Teil dieser Task sind).
+- Schema via `psql \d announcements` verifiziert: exakt die erwarteten Spalten
+  und Typen (`smallint` für `display_days`, `timestamp(0) without time zone`
+  für `expires_at`, Index `announcements_expires_at_index` auf `expires_at`).
+- `php artisan migrate:rollback --step=1` → Tabelle korrekt entfernt
+  (`\dt` zeigt sie danach nicht mehr).
+- Erneutes `php artisan migrate` (nur der Announcements-Migration) → lief
+  danach wieder fehlerfrei durch (Idempotenz von up/down bestätigt).
+
+**MySQL:** `docker-compose.mysql.yml` existiert **nicht** im Repository
+(geprüft, kein Treffer bei `find . -iname "*mysql*"` außerhalb von
+`openspec/triage/`). CLAUDE.md Abschnitt 7.1 referenziert diese Datei, sie ist
+aber noch nicht angelegt — das ist ein bereits vom Skeptiker in einem anderen
+Kontext identifizierter, projektweiter Nachrüstbedarf (siehe CLAUDE.md
+Abschnitt 4.2 "Migrations-Test", verweist auf einen eigenen künftigen
+openspec-Change für die CI-Matrix). Da MySQL-Kompatibilität dennoch
+Akzeptanzkriterium dieser Task ist, wurde stattdessen ein temporärer,
+eigenständiger MySQL-8.0-Container (`docker run mysql:8.0`, verbunden mit dem
+bestehenden `dog-school-app_dog-school-network`) gestartet und die
+Laravel-App per Env-Overrides (`DB_CONNECTION=mysql`, `DB_HOST=...` etc.,
+`docker compose exec -e ...`) testweise dagegen migriert:
+- `php artisan migrate --force` → alle Migrationen inkl. der neuen
+  `announcements`-Tabelle liefen fehlerfrei durch.
+- Schema via `mysql ... DESCRIBE announcements` verifiziert: exakt die
+  erwarteten Spalten und Typen (`smallint unsigned` für `display_days`,
+  `timestamp` für `expires_at`, Index `announcements_expires_at_index`).
+- `php artisan migrate:rollback --step=1 --force` → Tabelle korrekt entfernt
+  (`SHOW TABLES LIKE 'announcements'` liefert danach kein Ergebnis mehr).
+- Der temporäre MySQL-Testcontainer wurde anschließend wieder entfernt
+  (`docker rm -f dog-school-mysql-test`), keine dauerhaften
+  Repository-Änderungen für diesen Test nötig.
+
+**Ergebnis:** Beide Datenbanktreiber (PostgreSQL via projektstandard
+`docker-compose.yml`, MySQL via temporärem Ad-hoc-Container mangels
+vorhandener `docker-compose.mysql.yml`) wurden erfolgreich getestet — sowohl
+`migrate` als auch `migrate:rollback` funktionieren fehlerfrei und erzeugen
+identische, treiberneutral erwartete Schemata.
+
+## Weitere lokale Checks
+
+- `php -l` → keine Syntaxfehler.
+- `vendor/bin/pint --test` → PASS (PSR-12-konform, kein `--fix` nötig).
+- `vendor/bin/pest --filter=SettingsValidation` (Stichprobe eines
+  bestehenden Feature-Tests, der via `RefreshDatabase` alle Migrationen
+  inkl. der neuen gegen SQLite in-memory ausführt) → 7/7 Tests grün, keine
+  Regression durch die neue Migration.
+- `composer qa`/`composer test`/`composer stan`/`composer compat-check`
+  existieren laut `composer.json` (Stand dieser Task) nicht im Projekt
+  (bereits von `verification.md` bestätigt) — daher nicht ausführbar; die
+  oben genannten Ersatzchecks (`php -l`, `pint`, `pest`) wurden stattdessen
+  verwendet.
+
+## Abweichungen von der Spec
+
+Keine. Migration entspricht 1:1 dem in `tasks.md`/`design.md` Abschnitt 2.2
+vorgegebenen Code.
+
+## Hinweis für nachfolgende Tasks / Reviewer
+
+- `docker-compose.mysql.yml` fehlt im Repo, obwohl CLAUDE.md Abschnitt 7.1
+  sie referenziert. Für zukünftige DB-bezogene Tasks in diesem Change (bzw.
+  als projektweite Nachrüstung) wäre ein eigener openspec-Change sinnvoll,
+  der diese Datei anlegt (siehe CLAUDE.md Abschnitt 4.2 "Migrations-Test" /
+  `add-db-matrix-ci`-Erwähnung). Für T01 wurde das Fehlen durch einen
+  gleichwertigen Ad-hoc-Test kompensiert (siehe oben).

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T02.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T02.notes.md
@@ -1,0 +1,160 @@
+# Task-Notes T02: Model `Announcement` + Factory
+
+**Change-ID:** add-announcement-banner
+**Agent:** dev-php
+**Status:** abgeschlossen
+
+---
+
+## Umgesetzte Dateien
+
+- `backend/app/Models/Announcement.php` (neu)
+- `backend/database/factories/AnnouncementFactory.php` (neu)
+
+Beide Dateien wurden gemäß `design.md` Abschnitt 2.3 übernommen (Code dort
+1:1 vorgegeben). Nach `vendor/bin/pint`-Autofix weichen beide Dateien
+minimal von der wörtlichen Code-Vorlage in `design.md` ab (voll
+qualifizierte Klassennamen im PHPDoc durch `use`-Import + Kurzform ersetzt,
+String-Konkatenation `.` statt `. `) — rein stilistisch, keine
+Verhaltensänderung. Siehe Abschnitt "Lint" unten.
+
+## Abhängigkeit T01
+
+Migration `backend/database/migrations/2026_07_17_100000_create_announcements_table.php`
+war bereits vorhanden (`php artisan migrate` innerhalb des laufenden
+Docker-Containers meldete `Nothing to migrate.`). Tabellenschema
+(`title`, `body`, `image_path`, `display_days`, `expires_at`, Timestamps)
+wurde vor der Implementierung gegen die Spalten-/Cast-Zuordnung im Model
+verifiziert (`Read` der Migrationsdatei).
+
+## Verifikation der `booted()`-Hook-Logik (vor Übernahme geprüft)
+
+Der Skeptiker-Hinweis in `design.md` Abschnitt 2.1 verlangte eine
+eigenständige Prüfung, da es **kein** Vorbild für `booted()`/`saving`-Hooks
+im Projekt gibt (`CustomerCredit.php` verifiziert: kein solcher Hook,
+`expiration_date` wird dort direkt vom Client bzw. der Factory gesetzt).
+Geprüft anhand des Laravel-Framework-Quellcodes
+(`vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php`,
+Methoden `save()` Zeile 1138 ff., `performInsert()` Zeile 1301 ff.,
+`performUpdate()` Zeile 1217 ff.):
+
+1. **Kein Endlos-Rekursions-Risiko:** `saving` wird einmalig pro `save()`-
+   Aufruf gefeuert, bevor `performInsert()`/`performUpdate()` läuft. Der
+   Hook setzt nur ein Attribut (`$announcement->expires_at = ...`), ruft
+   selbst kein `save()` auf — kein Trigger einer erneuten `saving`-Kaskade.
+2. **Reihenfolge bei Create:** `saving` feuert **vor** `updateTimestamps()`
+   in `performInsert()` — zum Zeitpunkt des Hooks ist `created_at` bei
+   einem neuen Datensatz noch `null`. Der Hook-Code prüft das explizit
+   (`$announcement->exists` ist bei Create `false`) und fällt in diesem
+   Fall korrekt auf `now()` als Basis zurück, statt auf ein noch nicht
+   gesetztes `created_at` zuzugreifen.
+3. **Reihenfolge bei Update:** `saving` feuert vor `performUpdate()`, das
+   nur `updated_at` (nicht `created_at`) neu setzt. Das bereits vom Model
+   geladene `created_at` bleibt zum Hook-Zeitpunkt unverändert vorhanden —
+   der Hook liest also korrekt den ursprünglichen Anlage-Zeitpunkt.
+4. **Kein Überschreiben des Factory-`expired()`-States:** `saveQuietly()`
+   (Laravel-Standard) unterdrückt sämtliche Model-Events inkl. `saving` —
+   der Hook läuft beim `forceFill(...)->saveQuietly()` in
+   `AnnouncementFactory::expired()` nicht, die manuell in die Vergangenheit
+   gesetzten Werte bleiben also erhalten. Per Tinker verifiziert (siehe
+   unten, AC2).
+
+Ergebnis: Die in `design.md` vorgeschlagene Hook-Implementierung ist
+funktional korrekt und wurde unverändert übernommen.
+
+## Abweichungen von der wörtlichen Vorlage in `design.md`
+
+Keine inhaltlichen Abweichungen. `vendor/bin/pint` (Projekt-Lint-Tool,
+Laravel-Preset) hat beim Auto-Fix zwei rein stilistische Anpassungen
+vorgenommen:
+
+- PHPDoc: `\Illuminate\Support\Carbon` → `use`-Import + `Carbon` (Kurzform),
+  ebenso `@extends \Illuminate\...\Factory<\App\Models\Announcement>` →
+  `@extends Factory<Announcement>`.
+- String-Konkatenation ohne Leerzeichen um den Punkt
+  (`'<p>'.fake()->paragraph().'</p>'` statt `'<p>' . fake()->paragraph() . '</p>'`).
+
+Beide Anpassungen sind reine Formatierung ohne Verhaltensänderung.
+
+## Anmerkung zu Projekt-Tooling (Diskrepanz CLAUDE.md vs. tatsächlichem Zustand)
+
+CLAUDE.md Abschnitt 5/7.1 verweist auf `composer qa` (`lint` + `stan` +
+`compat-check` + `test`). Das im laufenden Docker-Container aktive
+`backend/composer.json` (gemountet unter `/var/www/html`, `App\` →
+`backend/app/`) definiert diese Scripts **nicht** — nur Standard-
+Composer-Hooks. `vendor/bin/phpstan` und `vendor/bin/phpcs` sind in
+`backend/vendor/bin/` nicht vorhanden (nur `pint`, `pest`, `phpunit` u. a.).
+Ein root-`composer.json` mit `qa`/`stan`/`compat-check`-Scripts existiert
+zwar im Projekt-Root, referenziert dort aber `app/`/`database/`, die es am
+Root nicht gibt (nur unter `backend/`) — dieses Root-`composer.json`
+scheint nicht das im Docker-Setup verwendete zu sein (`docker-compose.yml`
+mountet `./backend` nach `/var/www/html`). Für T02 daher ausgeführt:
+`vendor/bin/pint --test` (Lint, grün) und `vendor/bin/pest` (voller
+Testlauf, grün, keine Regression). `stan`/`compat-check` konnten mangels
+installierter Binaries nicht lokal ausgeführt werden — der neue Code
+verwendet ausschließlich PHP-8.2-kompatible Sprachfeatures (siehe
+"Manuelle PHP-8.2-Prüfung" unten), sodass kein inhaltliches Risiko besteht.
+Diese Diskrepanz ist ein bestehender Zustand des Projekts, nicht durch T02
+verursacht, und wird hier zur Dokumentation festgehalten
+(Anti-Halluzinations-Regel 3 aus CLAUDE.md Abschnitt 9).
+
+## Manuelle PHP-8.2-Prüfung (CLAUDE.md Abschnitt 4.1)
+
+Keines der in Abschnitt 4.1 verbotenen 8.3-/8.4-Konstrukte verwendet:
+keine Property Hooks, keine Asymmetric Visibility, kein `#[\Override]`,
+keine typed Class Constants, kein `json_validate()`, keine Dynamic Class
+Constant Fetch, kein `new MyClass()->method()` ohne Klammern. Verwendet
+werden ausschließlich seit 8.2 erlaubte Features (Readonly-fähige Klasse
+möglich, aber hier nicht genutzt; `protected function casts(): array`
+Laravel-11-Konvention).
+
+## Lokale Verifikation (Docker, PostgreSQL)
+
+Ausgeführt in `dog-school-php`-Container gegen die lokale PostgreSQL-
+Entwicklungsdatenbank via `php artisan tinker`:
+
+```
+AC1 (create() -> expires_at = created_at + display_days):
+  created_at=2026-07-17 09:42:54 expires_at=2026-07-22 09:42:54 display_days=5
+  diffInSeconds zwischen expires_at und created_at+5d: 0 -> PASS
+
+AC2 (expired()->create() -> isActive() === false):
+  created_at=2026-07-07 09:42:54 expires_at=2026-07-08 09:42:54
+  isActive(): false -> PASS
+
+AC3 (display_days auf bestehendem, nicht abgelaufenem Datensatz erhöht
+     -> expires_at neu ab ursprünglichem created_at, nicht ab now()):
+  ursprüngliches created_at=2026-07-17 09:42:54 (unverändert nach Update)
+  display_days 3 -> 10 (nach 1s Wartezeit gespeichert)
+  neues expires_at=2026-07-27 09:42:54 == created_at + 10 Tage -> PASS
+
+AC4 (scopeActive() liefert nur expires_at > now()):
+  1 aktiver + 1 abgelaufener Datensatz angelegt
+  Announcement::active()->pluck('id') enthält nur den aktiven Datensatz
+  -> PASS
+```
+
+Test-Datensätze anschließend aus der Entwicklungs-DB gelöscht
+(`Announcement::query()->delete()`), Tinker-Skript aus dem Container
+entfernt — keine Rückstände.
+
+## QA-Checks
+
+- `vendor/bin/pint --test app/Models/Announcement.php
+  database/factories/AnnouncementFactory.php` → PASS (nach einmaligem
+  `vendor/bin/pint`-Autofix, siehe oben)
+- `vendor/bin/pest` (voller Suite-Lauf) → 693 passed (2195 assertions),
+  keine Regression durch die neuen Dateien
+- `php artisan migrate` → `Nothing to migrate.` (T01-Migration bereits
+  vorhanden und unverändert)
+
+## Bekannte Einschränkungen / Hinweise für Folge-Tasks
+
+- T02 selbst enthält keine formalen Pest-Tests für `Announcement`
+  (`vendor/bin/pest --filter=Announcement` meldet `No tests found.`) —
+  das ist laut `tasks.md` explizit Aufgabe von T08
+  (`AnnouncementApiTest.php`). Die vier Akzeptanzkriterien wurden für T02
+  stattdessen wie oben dokumentiert per Tinker verifiziert.
+- `expired()`-Factory-State setzt `created_at`/`expires_at` fix auf
+  `now()->subDays(10)`/`now()->subDays(9)` (unabhängig von
+  `display_days`) — entspricht exakt der Vorgabe in `design.md`.

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T03.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T03.notes.md
@@ -1,0 +1,56 @@
+# Task T03: Policy `AnnouncementPolicy`
+
+**Agent:** dev-php
+**Status:** abgeschlossen
+
+## Implementiert
+
+- `backend/app/Policies/AnnouncementPolicy.php` (neu)
+
+## Vorgehen
+
+Policy 1:1 analog zu `backend/app/Policies/SettingPolicy.php` erstellt: alle
+fünf Standard-Methoden (`viewAny`, `view`, `create`, `update`, `delete`)
+prüfen ausschließlich `$user->isAdmin()`. Code entspricht exakt dem in
+`design.md` Abschnitt 4.1 vorgegebenen Muster, mit PHPDoc-Kommentaren im
+Stil von `DogPolicy.php`/`SettingPolicy.php` ergänzt.
+
+`declare(strict_types=1);` gesetzt, PSR-12-konform (`vendor/bin/pint --test`
+bestätigt).
+
+## Policy-Discovery geprüft
+
+`backend/app/Providers/` enthält ausschließlich `AppServiceProvider.php` —
+kein `AuthServiceProvider` mit manueller `$policies`-Map. Laravel 11 löst
+`App\Models\Announcement` → `App\Policies\AnnouncementPolicy` daher über die
+Standard-Namenskonvention (`Model`-Namespace → `Policies`-Namespace,
+Suffix `Policy`) automatisch auf, identisch zum bestehenden Verhalten von
+`SettingPolicy`/`DogPolicy`. Kein manueller Eintrag nötig, keine Änderung an
+`AppServiceProvider.php` vorgenommen.
+
+## Abhängigkeit T02
+
+`App\Models\Announcement` existierte bereits vor Beginn dieser Task unter
+`backend/app/Models/Announcement.php` (T02 bereits erledigt) — Policy
+referenziert dieses Model per `use App\Models\Announcement;`.
+
+## Pre-Flight-Checks (Docker-Umgebung, `docker compose exec php ...`)
+
+- `php -l app/Policies/AnnouncementPolicy.php` → keine Syntaxfehler
+- `vendor/bin/pint --test app/Policies/AnnouncementPolicy.php` → `PASS`
+- Kein `composer qa`/`composer stan`/`composer compat-check`-Script im
+  Repo vorhanden (siehe bereits in T01 dokumentiert, `composer.json`
+  enthält aktuell keine dieser Scripts) — daher nur Pint (Lint) und
+  `php -l` ausführbar. Manuelle Prüfung gegen CLAUDE.md Abschnitt 4.1:
+  keine PHP-8.3/8.4-Konstrukte verwendet (nur Standard-Klassen-Syntax,
+  typisierte Methoden-Parameter/Returns, kein `#[\Override]`, keine
+  Property Hooks, kein Readonly-Class-Level-Konstrukt nötig).
+- Kein Test-Lauf nötig/vorgesehen für T03 (Tests für die Policy sind
+  implizit Teil von T08, `AnnouncementApiTest.php`, über die
+  Authorization-Checks in den Controller-Aktionen).
+
+## Abweichungen von design.md
+
+Keine. Code entspricht 1:1 dem in `design.md` Abschnitt 4.1 spezifizierten
+Muster (Methodensignaturen identisch, nur um PHPDoc-Blöcke ergänzt,
+analog zum bestehenden Stil in `SettingPolicy.php`/`DogPolicy.php`).

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T04.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T04.notes.md
@@ -1,0 +1,124 @@
+# Task-Notes T04: FormRequests `StoreAnnouncementRequest` / `UpdateAnnouncementRequest`
+
+**Change-ID:** add-announcement-banner
+**Agent:** dev-php
+**Status:** abgeschlossen
+
+---
+
+## Umgesetzte Dateien
+
+- `backend/app/Http/Requests/StoreAnnouncementRequest.php` (neu)
+- `backend/app/Http/Requests/UpdateAnnouncementRequest.php` (neu)
+
+Beide Klassen wurden gemäß `design.md` Abschnitt 4.2/4.3 übernommen (Code
+dort im Wesentlichen 1:1 vorgegeben), im Aufbau eng an
+`StoreCourseRequest.php`/`UpdateCourseRequest.php` angelehnt (bestehendes
+Vorbild für die `SanitizesHtmlContent`-Trait-Nutzung, siehe unten).
+
+## Umsetzung im Detail
+
+- `StoreAnnouncementRequest::authorize()`: `$this->user()?->isAdmin() ?? false`
+  — identisches Muster wie `SettingPolicy`/andere Admin-only-Requests im
+  Projekt (`User::isAdmin()`, `backend/app/Models/User.php:91`).
+- `rules()`: `title` (`required|string|max:255`), `body`
+  (`required|string|max:5000`, Grenze identisch zu
+  `StoreCourseRequest.php:38`), `displayDays`
+  (`required|integer|min:1|max:365`), `image`
+  (`nullable|image|mimes:jpg,jpeg,png,gif,webp|max:5120`, identisch zu
+  `DogController.php:185`).
+- `validatedSnakeCase()` in `StoreAnnouncementRequest`: baut das Array
+  **explizit** aus `title`/`body`/`display_days` auf (kein generisches
+  `Str::snake()`-Mapping über alle validierten Keys wie in
+  `StoreCourseRequest`) — dadurch landet `image` (camelCase `image`, es
+  gibt hier ohnehin keine Snake-Case-Konvertierung nötig, da der Key schon
+  `image` lautet) **strukturell nicht** im Rückgabe-Array. `body` wird vor
+  der Rückgabe über `sanitizeHtmlDescription()` bereinigt.
+- `UpdateAnnouncementRequest::rules()`: alle Felder mit `sometimes`
+  (Teil-Update), `image` bleibt `nullable` (keine `sometimes`-Notwendigkeit
+  bei einem ohnehin optionalen Feld).
+- `UpdateAnnouncementRequest::validatedSnakeCase()`: baut das
+  Rückgabe-Array iterativ per `array_key_exists()`-Prüfung pro Feld auf —
+  nur tatsächlich im Request vorhandene Felder erscheinen im Ergebnis,
+  `image` wird bewusst nie in dieses Array übernommen (Bild-Upload bleibt
+  Aufgabe des Controllers in T06, `$request->hasFile('image')`).
+- Beide Klassen nutzen `App\Http\Requests\Concerns\SanitizesHtmlContent`
+  (bestehendes Trait, keine neue Abhängigkeit,
+  `backend/app/Http/Requests/Concerns/SanitizesHtmlContent.php` gelesen und
+  unverändert wiederverwendet).
+
+## Abweichung von der wörtlichen Design-Vorlage
+
+Keine inhaltliche Abweichung. `vendor/bin/pint` hat nach dem Schreiben der
+Dateien automatisch zwei rein stilistische Fixer angewendet
+(`fully_qualified_strict_types`, `ordered_imports`): der PHPDoc-Rückgabetyp
+`\Illuminate\Contracts\Validation\ValidationRule` in `rules()` wurde durch
+einen `use`-Import + Kurzform (`ValidationRule`) ersetzt. Dieselben zwei
+Fixer schlagen mit identischem Befund auch bei den bestehenden Vorbildern
+`StoreCourseRequest.php`/`UpdateCourseRequest.php` an (`vendor/bin/pint
+--test` dort ebenfalls nicht grün) — vorbestehender Projektzustand, nicht
+durch T04 verursacht.
+
+## Lokale Verifikation (Docker-Container `dog-school-php`)
+
+Ausgeführt über `php artisan tinker <script>` (Skript danach aus dem
+Container entfernt bzw. lag unter `/tmp`, keine Repo-Änderung):
+
+```
+rules keys: title,body,displayDays,image
+displayDays=0 fails: true
+displayDays=366 fails: true
+displayDays=365 fails: false
+sanitized: <p>Hallo</p>alert(1)<strong>bold</strong>
+update rules: {"title":["sometimes","string","max:255"],"body":["sometimes","string","max:5000"],"displayDays":["sometimes","integer","min:1","max:365"],"image":["nullable","image","mimes:jpg,jpeg,png,gif,webp","max:5120"]}
+authorize() mit ungebundenem User (kein Sanctum-Auth im Testkontext): false
+```
+
+- `displayDays=0`/`displayDays=366` → Validierung schlägt fehl (führt bei
+  echtem Request zu HTTP 422 über den Standard-Laravel-Validation-Flow) —
+  AC "displayDays außerhalb 1–365 wird abgelehnt" bestätigt.
+- `displayDays=365` (Grenzwert, inklusive) → Validierung erfolgreich —
+  bestätigt `max:365` als inklusive Obergrenze.
+- `sanitizeHtmlDescription()` entfernt `<script>`-Tag vollständig und
+  streift das `onclick`-Attribut vom erlaubten `<strong>`-Tag, behält aber
+  erlaubte Tags (`<p>`, `<strong>`) — AC "body wird bereinigt" bestätigt.
+- `authorize()` liefert `false`, wenn kein Sanctum-authentifizierter Admin
+  gebunden ist — AC bestätigt (der Positivfall "ist Admin → `true`" folgt
+  direkt aus `$this->user()?->isAdmin()` und wird in T08
+  (`AnnouncementApiTest`) end-to-end gegen echte Admin-/Nicht-Admin-User
+  abgedeckt).
+- `image` erscheint in keinem der beiden `validatedSnakeCase()`-Codepfade
+  als Schlüssel — durch Code-Inspektion bestätigt (explizite
+  Allowlist-Konstruktion des Rückgabe-Arrays in beiden Klassen, siehe
+  oben), nicht separat per Tinker nachgestellt, da kein Dateiupload ohne
+  echten `UploadedFile`/Multipart-Request sinnvoll simulierbar ist — wird
+  in T08 mit `Storage::fake('public')` end-to-end getestet.
+
+## QA-Checks
+
+- `php -l` auf beiden neuen Dateien → keine Syntaxfehler.
+- `vendor/bin/pint --test app/Http/Requests/StoreAnnouncementRequest.php
+  app/Http/Requests/UpdateAnnouncementRequest.php` → PASS (nach einmaligem
+  `vendor/bin/pint`-Autofix, siehe oben).
+- `vendor/bin/pest --filter=Course` (Regressionstest der strukturell
+  ähnlichsten bestehenden FormRequests/Feature-Tests, da T04 selbst noch
+  keine eigenen Tests hat — die sind T08 vorbehalten) → 116 passed (330
+  assertions), keine Regression.
+- `stan`/`compat-check`: wie bereits in `task-T02.notes.md` dokumentiert,
+  im Docker-Container nicht als `vendor/bin/*`-Binary vorhanden (Diskrepanz
+  CLAUDE.md vs. tatsächlichem Projekt-Setup, vorbestehend, nicht durch T04
+  verursacht). Manuelle PHP-8.2-Prüfung: keines der in CLAUDE.md
+  Abschnitt 4.1 verbotenen 8.3-/8.4-Konstrukte verwendet (nur Nullsafe-
+  Operator `?->`, First-Class-Standardsyntax, Standard-Typdeklarationen —
+  alle seit PHP 8.0/8.1 verfügbar).
+
+## Bekannte Einschränkungen / Hinweise für Folge-Tasks
+
+- T04 selbst enthält keine formalen Pest-Tests für die neuen
+  FormRequest-Klassen — das ist laut `tasks.md` explizit Aufgabe von T08
+  (`AnnouncementApiTest.php`, inkl. `assertJsonValidationErrors(['displayDays'])`
+  und Sanitizing-Verifikation über `assertDatabaseHas`).
+- T06 (Controller) ist die einzige Stelle, die `$request->hasFile('image')`
+  auswertet und den Upload-Pfad separat in `image_path` überführt — T04
+  liefert dafür bewusst nur die validierte `UploadedFile`-Instanz über
+  `$request->file('image')` (nicht Teil von `validatedSnakeCase()`).

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T05.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T05.notes.md
@@ -1,0 +1,91 @@
+# Task-Notes T05: Resource `AnnouncementResource`
+
+**Agent:** dev-php
+**Status:** abgeschlossen
+
+## Umgesetzte Dateien
+
+- `backend/app/Http/Resources/AnnouncementResource.php` *(neu)*
+
+## Umsetzung
+
+Die Resource wurde exakt nach dem in `design.md` Abschnitt 4.4 ("Backend —
+Policy, FormRequests, Resource") vorgegebenen Code implementiert (der
+Task-Beschreibungstext verweist auf "Abschnitt 5.1", der vollständige
+Resource-Code und das verbindliche JSON-Beispiel befinden sich jedoch in
+Abschnitt 4.4 — Abschnitt 5.1 enthält den Controller-Code, der die Resource
+lediglich verwendet). Feldreihenfolge und -namen entsprechen 1:1 dem
+verbindlichen JSON-Beispiel:
+
+```
+id, title, body, imageUrl, displayDays, expiresAt, isActive, createdAt, updatedAt
+```
+
+- `imageUrl`: `Storage::disk('public')->url($this->image_path)`, `null` falls
+  `image_path` nicht gesetzt ist (Ternary-Ausdruck, identisches Muster wie
+  `DogResource::profileImageUrl`, `backend/app/Http/Resources/DogResource.php:45-47`).
+- `expiresAt`/`createdAt`/`updatedAt`: `toISOString()` mit Null-Safe-Operator
+  (`?->`), analog `DogResource.php:48-50`.
+- `isActive`: ruft `Announcement::isActive()` (aus T02,
+  `backend/app/Models/Announcement.php:77-80`) auf, kein eigenes
+  Aktiv-Kriterium dupliziert.
+
+Stilistisch an `DogResource.php` angelehnt (Klassen-PHPDoc mit `@mixin`,
+Methoden-PHPDoc `@return array<string, mixed>`). `vendor/bin/pint` hat beim
+`--test`-Lauf einen Formatierungshinweis zum `@mixin`-Tag ausgegeben
+(`fully_qualified_strict_types`: bevorzugt `use App\Models\Announcement;` +
+Kurzname im PHPDoc statt voll qualifiziertem Klassennamen inline). Mit
+`vendor/bin/pint` automatisch korrigiert; `--test` läuft danach grün. Hinweis:
+`DogResource.php` selbst hat denselben (unkorrigierten) Stil und würde bei
+`pint --test` ebenfalls anschlagen — das ist ein vorbestehender Zustand,
+nicht Teil dieser Task, daher nicht angefasst.
+
+## Abweichungen vom vorgesehenen Code
+
+Keine inhaltlichen Abweichungen. Einzige Ergänzung gegenüber dem
+Code-Snippet in `design.md` 4.4: Klassen-Level-PHPDoc (`@mixin`) und
+Methoden-PHPDoc (`@return array<string, mixed>`), übernommen aus dem
+bestehenden `DogResource.php`-Muster zur Konsistenz mit dem restlichen
+Resource-Bestand.
+
+## PHP-8.2-Kompatibilität
+
+Keine 8.3/8.4-Features verwendet (kein `readonly class`-Marker-Attribut,
+keine Typed Class Constants, kein `#[\Override]`, keine Dynamic Class
+Constant Fetch, kein `new ...->` ohne Klammern). Nullsafe-Operator (`?->`)
+ist seit PHP 8.0 verfügbar, ternäre Ausdrücke und Match sind Standard-PHP —
+unkritisch.
+
+## Lokale Checks
+
+Ausgeführt in `dog-school-php`-Docker-Container (`cd /var/www/html`):
+
+- `vendor/bin/pint --test app/Http/Resources/AnnouncementResource.php` →
+  zunächst 1 Style-Issue (siehe oben), nach `vendor/bin/pint` (Fix) grün.
+- `php -l app/Http/Resources/AnnouncementResource.php` → keine
+  Syntaxfehler.
+- `composer dump-autoload` → 8438 Klassen erfolgreich generiert, neue
+  Klasse ohne Namespace-/Autoload-Konflikt aufgelöst.
+
+**Nicht ausführbar (bestehende Infrastruktur-Lücke, nicht Teil von T05):**
+`composer qa` ist in `backend/composer.json` nicht definiert (nur im
+Root-`composer.json` des Repos, das sich aber auf nicht-existente
+Root-Pfade `app/`, `database/` etc. bezieht — das Backend liegt unter
+`backend/`). `backend/composer.json` `require-dev` enthält weder
+`larastan/larastan` noch `phpcompatibility/php-compatibility`, entsprechend
+existieren `vendor/bin/phpstan` und `vendor/bin/phpcs` in
+`backend/vendor/` nicht. `composer stan` und `composer compat-check` konnten
+daher nicht ausgeführt werden. Dies betrifft alle Backend-Tasks dieses
+Changes gleichermaßen und ist kein durch T05 verursachtes Problem — ggf.
+als eigener Findings-Punkt für den Skeptiker/Reviewer relevant.
+`composer test` (Pest) wurde nicht separat für T05 ausgeführt, da T08 die
+zugehörigen Feature-Tests erst noch liefert; die Resource-Datei selbst
+enthält keine testbare Logik über das reine Mapping hinaus.
+
+## Für T09 (Frontend) relevant
+
+Response-Shape ist exakt wie in `design.md` Abschnitt 4.4/"Verbindliches
+JSON-Beispiel" fixiert — camelCase-Feldnamen `id`, `title`, `body`,
+`imageUrl`, `displayDays`, `expiresAt`, `isActive`, `createdAt`, `updatedAt`,
+1:1 übernommen, keine Abweichungen. T09 kann das TypeScript-Interface
+`Announcement` direkt danach modellieren.

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T06.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T06.notes.md
@@ -1,0 +1,125 @@
+# Notes T06: Controller `Api/AnnouncementController`
+
+**Agent:** dev-php
+**Status:** abgeschlossen
+
+## Umgesetzt
+
+- Neue Datei `backend/app/Http/Controllers/Api/AnnouncementController.php`.
+- Fünf öffentliche Methoden gemäß `design.md` Abschnitt 5.1:
+  - `publicIndex(): AnonymousResourceCollection` — ungeschützt,
+    `Announcement::query()->active()->orderByDesc('created_at')->get()`
+    (nutzt `scopeActive()` aus T02), gewrappt über
+    `AnnouncementResource::collection()`.
+  - `index(): AnonymousResourceCollection` — `$this->authorize('viewAny',
+    Announcement::class)`, liefert alle Datensätze (aktiv + abgelaufen).
+  - `store(StoreAnnouncementRequest $request): JsonResponse` — keine
+    zusätzliche `$this->authorize()`-Prüfung (analog `DogController::store()`),
+    Autorisierung erfolgt ausschließlich über
+    `StoreAnnouncementRequest::authorize()`. Bild-Upload nur bei
+    `$request->hasFile('image')`, HTTP 201.
+  - `update(UpdateAnnouncementRequest $request, Announcement $announcement):
+    AnnouncementResource` — `$this->authorize('update', $announcement)`,
+    löscht bei neuem Upload zuerst das alte Bild, dann Ersetzung.
+  - `destroy(Announcement $announcement): JsonResponse` — `$this->authorize(
+    'delete', $announcement)`, löscht Bild von Disk vor dem Löschen des
+    Datensatzes, HTTP 204.
+- Zwei private Hilfsmethoden:
+  - `storeImage(Request $request): string` — Upload-Handling identisch zum
+    Muster in `DogController::uploadImage()`
+    (`backend/app/Http/Controllers/Api/DogController.php:180-202`):
+    `Str::uuid()`-Dateiname (`announcement_<uuid>.<ext>`),
+    `$file->storeAs('announcement-images', $filename, 'public')`.
+  - `deleteImageIfExists(Announcement $announcement): void` — kleine
+    Extraktion (DRY) der in `design.md` in `update()`/`destroy()`
+    duplizierten Lösch-Prüfung (`Storage::disk('public')->exists(...) →
+    delete(...)`); Verhalten ist identisch zum Design-Vorschlag, nur ohne
+    Code-Duplikation zwischen den beiden Aufrufstellen.
+
+## Abweichungen vom `design.md`-Codebeispiel
+
+- `deleteImageIfExists()` als privates Hilfsmethode extrahiert statt den
+  Lösch-Block in `update()` und `destroy()` zu duplizieren (DRY-Prinzip aus
+  CLAUDE.md Abschnitt "Vorgehen"). Verhalten entspricht exakt dem in
+  `design.md` Abschnitt 5.1 beschriebenen Code.
+- `vendor/bin/pint` hat beim ersten Lauf automatisch PHPDoc-Blöcke bereinigt
+  (überflüssige `@param $request`/`@return`-Tags entfernt, die keinen
+  Mehrwert über die bereits typisierte Signatur hinaus bieten, sowie
+  Concat-Space-Formatierung `.`) — Projekt-Codestil-Automatik, keine
+  inhaltliche Änderung.
+
+## Abhängigkeiten (bereits vorhanden, nur gelesen)
+
+- `App\Policies\AnnouncementPolicy` (T03) — `viewAny`, `update`, `delete`.
+- `App\Http\Requests\StoreAnnouncementRequest` /
+  `UpdateAnnouncementRequest` (T04) — `authorize()`, `validatedSnakeCase()`.
+- `App\Http\Resources\AnnouncementResource` (T05) — `toArray()`.
+- `App\Models\Announcement` (T02) — `scopeActive()`.
+
+Keine dieser Dateien wurde verändert.
+
+## PHP-8.2-Kompatibilität (CLAUDE.md Abschnitt 4.1)
+
+Manuell geprüft (kein `compat-check`-Script im Projekt vorhanden, siehe
+`design.md` Abschnitt 10 / `proposal.md` "Out of Scope"): keine Property
+Hooks, keine Asymmetric Visibility, keine typisierten Klassenkonstanten,
+kein `#[\Override]`, kein `json_validate()`, keine der in Abschnitt 4.1
+gelisteten 8.3/8.4-Konstrukte verwendet. Nur Standard-Eloquent-/
+FormRequest-/Resource-/Storage-Facade-Aufrufe.
+
+## Route-Registrierung
+
+Bewusst **nicht** Teil dieser Task (T07). Der Controller ist so geschrieben,
+dass T07 ihn unverändert registrieren kann (Methodennamen `publicIndex`,
+`index`, `store`, `update`, `destroy` entsprechen exakt den in `design.md`
+Abschnitt 5.2 referenzierten Routen-Zielen).
+
+## Lokale Checks
+
+```
+cd backend
+php -l app/Http/Controllers/Api/AnnouncementController.php   # keine Syntaxfehler
+vendor/bin/pint --test app/Http/Controllers/Api/AnnouncementController.php  # passed
+```
+
+`composer qa` nicht ausführbar wie in CLAUDE.md beschrieben — die Scripts
+`lint`/`stan`/`compat-check`/`test` existieren aktuell nicht in
+`backend/composer.json` (nur `post-*`-Hooks und `dev`). Ersatzweise
+verwendet: `vendor/bin/pint` (Lint, vorhanden) und `php artisan test`
+(vollständige Suite, siehe unten). `vendor/bin/phpstan`/`vendor/bin/phpcs`
+sind nicht in `vendor/bin/` installiert — PHPStan/Larastan- und
+PHPCompatibility-Prüfung konnten daher nicht automatisiert ausgeführt
+werden; das deckt sich mit `design.md` Abschnitt 10
+("kein automatisiertes `compat-check`-Script vorhanden").
+
+```
+docker compose exec -T php php artisan test
+# Tests: 693 passed (2195 assertions) — keine Regression durch die neue Datei
+```
+
+## Manuelle Verifikation der Akzeptanzkriterien
+
+Da die Routen erst in T07 registriert werden (Feature-Tests folgen in T08),
+wurden die Controller-Methoden über ein temporäres Tinker-Skript direkt
+aufgerufen (gegen die lokale Docker-PostgreSQL-Instanz, `Storage::fake(
+'public')`). Skript wurde nach dem Lauf wieder entfernt, keine Testartefakte
+im Repo.
+
+| Akzeptanzkriterium | Ergebnis |
+|---|---|
+| `publicIndex()` liefert nur `expires_at > now()` | PASS — `Announcement::factory()->create()` (aktiv) erscheint, `Announcement::factory()->expired()->create()` erscheint **nicht** |
+| `index()` liefert alle (aktiv + abgelaufen) | PASS — beide Test-Datensätze erscheinen für Admin |
+| `store()` speichert Bild unter `announcement-images/`, setzt `image_path` | PASS — `image_path` beginnt mit `announcement-images/`, `Storage::disk('public')->assertExists(...)` grün, `imageUrl` im Response korrekt gesetzt |
+| `update()` löscht altes Bild bei neuem Upload | PASS — `Storage::disk('public')->assertMissing($oldImagePath)` nach Update mit neuem Bild grün, neues Bild existiert |
+| `destroy()` löscht zugehöriges Bild | PASS — `Storage::disk('public')->assertMissing(...)` nach `destroy()` grün, Datensatz aus DB entfernt (204) |
+| `index`/`store`/`update`/`destroy` → HTTP 403 für Nicht-Admin | PASS — `index()`/`update()`/`destroy()` werfen `AuthorizationException` (durch `$this->authorize()`, wird von Laravels Exception-Handler zu HTTP 403 gemappt); `StoreAnnouncementRequest::authorize()` liefert `false` für Nicht-Admin (wird von Laravels FormRequest-Validierung ebenfalls zu HTTP 403 gemappt) |
+
+Zusätzlich verifiziert: `body` wird beim `store()`-Aufruf serverseitig
+sanitized (`<script>alert(1)</script>` wurde aus dem Response-`body`
+entfernt) — Bestätigung, dass `StoreAnnouncementRequest::validatedSnakeCase()`
+korrekt vom Controller verwendet wird.
+
+## Nicht Teil dieser Task
+
+- Routen-Registrierung (`backend/routes/api.php`) — T07.
+- Feature-Tests (`AnnouncementApiTest`) — T08.

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T07.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T07.notes.md
@@ -1,0 +1,110 @@
+# Notes T07: Routen-Ergänzung `backend/routes/api.php`
+
+**Change-ID:** add-announcement-banner
+**Agent:** dev-php
+**Datei geändert:** `backend/routes/api.php`
+
+## Umsetzung
+
+Die tatsächlichen Zeilennummern in `backend/routes/api.php` wichen leicht von
+den in `design.md` Abschnitt 5.2 genannten ab (Datei hatte sich seit
+Design-Erstellung verschoben). Ich habe die Einfügepunkte anhand der dort
+beschriebenen Anker (bestehende Kommentar-Blöcke) im aktuellen Dateistand neu
+verifiziert, statt die genannten Zeilennummern blind zu übernehmen.
+
+1. **`use`-Import** (vorher Zeile 5-27, jetzt Zeile 5-28):
+   `use App\Http\Controllers\Api\AnnouncementController;` alphabetisch
+   zwischen `App\Http\Controllers\AnamnesisTemplateController` (Zeile 6) und
+   `App\Http\Controllers\Api\AuthController` (vorher Zeile 7) eingefügt.
+   Sortierlogik verifiziert: Der bestehende Import-Block ist nach dem vollen
+   FQCN-String sortiert (`AnamnesisTemplateController` < `Api\Announcement…`
+   < `Api\AuthController`, da `n` < `u` beim ersten abweichenden Zeichen nach
+   dem gemeinsamen Präfix `Api\A`).
+
+2. **Öffentliche Route** — neuer Block direkt nach dem bestehenden
+   "Public pricing route"-Block (Zeile 55-58 im aktuellen Stand, nicht
+   54-57 wie in `design.md` vermerkt — Verschiebung um eine Zeile durch den
+   zusätzlichen `use`-Import), vor dem "Public course detail route"-Block:
+
+   ```php
+   // Public announcements route (no auth required)
+   Route::prefix('v1')->group(function () {
+       Route::get('/announcements', [AnnouncementController::class, 'publicIndex']);
+   });
+   ```
+
+3. **Admin-Routen** — neuer Block innerhalb der bestehenden
+   `Route::prefix('v1')->middleware('auth:sanctum')->group(...)`-Gruppe, nach
+   dem "Settings Management"-Block (aktueller Stand Zeile 198-202, nicht
+   192-195 wie in `design.md` vermerkt — gleiche Verschiebung), vor der
+   schließenden `});` der `auth:sanctum`-Gruppe:
+
+   ```php
+   // Announcement Management (Admin only)
+   Route::middleware('can:admin')->group(function () {
+       Route::get('/admin/announcements', [AnnouncementController::class, 'index']);
+       Route::post('/admin/announcements', [AnnouncementController::class, 'store']);
+       Route::put('/admin/announcements/{announcement}', [AnnouncementController::class, 'update']);
+       Route::delete('/admin/announcements/{announcement}', [AnnouncementController::class, 'destroy']);
+   });
+   ```
+
+   Folgt exakt dem bestehenden Muster des "Settings Management"-Blocks
+   (eigenes `Route::middleware('can:admin')->group(...)` innerhalb der
+   äußeren `auth:sanctum`-Gruppe, analog zu `SettingsController`- und
+   `TrainerController`-Routen).
+
+## Verifikation
+
+```
+docker compose exec php php artisan route:list | grep -i announcement
+```
+
+Ergebnis (alle fünf Routen korrekt registriert):
+
+```
+GET|HEAD        api/v1/admin/announcements Api\AnnouncementController@index
+POST            api/v1/admin/announcements Api\AnnouncementController@store
+PUT             api/v1/admin/announcements/{announcement} Api\AnnouncementController@update
+DELETE          api/v1/admin/announcements/{announcement} Api\AnnouncementController@destroy
+GET|HEAD        api/v1/announcements Api\AnnouncementController@publicIndex
+```
+
+- `GET /api/v1/announcements` liegt außerhalb der `auth:sanctum`-Gruppe →
+  ohne Authentifizierung erreichbar.
+- Alle vier Admin-Routen liegen innerhalb `auth:sanctum` **und** zusätzlich
+  innerhalb des neuen `can:admin`-Middleware-Blocks.
+
+## Pre-Flight-Checks (CLAUDE.md Abschnitt 7.1)
+
+- `docker compose exec php php artisan route:list | grep announcement` — alle
+  fünf Routen korrekt (siehe oben).
+- `docker compose exec php ./vendor/bin/pest --group=api` — 124 Tests grün,
+  keine Regression durch die Routen-Änderung.
+- `docker compose exec php ./vendor/bin/pint --test routes/api.php` meldet
+  1 Style-Issue (`no_extra_blank_lines`/`no_whitespace_in_blank_line` u. a.).
+  **Verifiziert per `git diff backend/routes/api.php`:** Dieses Issue betrifft
+  ausschließlich vorbestehende Zeilen (trailing whitespace auf Leerzeilen,
+  fehlender Zeilenumbruch am Dateiende), die bereits vor meiner Änderung im
+  Datei-Stand vorhanden waren — mein Diff fügt ausschließlich neue,
+  sauber formatierte Zeilen hinzu und ändert keine bestehende Zeile. Diese
+  vorbestehende Formatierungsabweichung liegt außerhalb des Scopes von T07
+  (keine fremden Zeilen anfassen) und wird hier nur dokumentiert, nicht
+  behoben.
+- `composer.json` (Backend) enthält aktuell keine `qa`/`lint`/`stan`/
+  `compat-check`-Scripts (nur `post-*`-Hooks und `dev`) — entspricht dem in
+  `proposal.md`/`design.md` Abschnitt 10 dokumentierten Befund ("kein
+  automatisiertes `compat-check`-Script im Projekt vorhanden"). Manuelle
+  Prüfung: Der T07-Diff verwendet ausschließlich PHP-8.2-kompatible Syntax
+  (ein `use`-Import, `Route::`-Facade-Aufrufe) — keine der in CLAUDE.md
+  Abschnitt 4.1 gelisteten 8.3/8.4-Konstrukte.
+
+## Offene Punkte / Hinweise für Reviewer
+
+- Keine funktionale Abweichung von `design.md` Abschnitt 5.2 — nur die
+  Zeilennummern-Referenzen im Design-Dokument sind durch den zusätzlichen
+  `use`-Import um jeweils eine Zeile verschoben (kosmetisch, keine
+  inhaltliche Abweichung).
+- Der vorbestehende Pint-Befund in `routes/api.php` (siehe oben) besteht
+  unabhängig von T07 weiter und wäre ein eigener, kleiner Aufräum-Task,
+  falls gewünscht.

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T08.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T08.notes.md
@@ -1,0 +1,95 @@
+# Notes T08 — Backend-Tests `AnnouncementApiTest`
+
+**Agent:** dev-php
+**Status:** abgeschlossen
+
+## Umgesetzt
+
+- Neue Datei `backend/tests/Feature/Api/AnnouncementApiTest.php` mit 11
+  `it(...)`-Tests, Gruppen `api`, `announcement`, `RefreshDatabase`.
+- Alle in `tasks.md` geforderten Szenarien als eigene Tests:
+  1. Öffentlicher Endpunkt liefert nur aktive Ankündigungen
+     (`expired()`-Announcement erscheint nicht in `data`).
+  2. Admin-Endpunkt (`GET /api/v1/admin/announcements`) liefert aktive
+     **und** abgelaufene Ankündigungen.
+  3. Nicht-Admin erhält HTTP 403 auf alle vier Admin-Aktionen
+     (`index`, `store`, `update`, `destroy`) — als vier separate Tests,
+     nicht als eine Sammel-Assertion, damit ein Fehlschlag in einer Aktion
+     nicht die Prüfung der anderen verdeckt.
+  4. `store()` mit Bild-Upload: `image_path` wird gesetzt, Datei existiert
+     auf der gefakten `public`-Disk, `imageUrl` im Response entspricht
+     exakt `Storage::disk('public')->url($created->image_path)`.
+  5. Sanitizing-Verifikation: `<p onclick="alert(1)">Hallo</p><script>alert(1)</script>`
+     wird zu `<p>Hallo</p>alert(1)` bereinigt (Verifikation des exakten
+     Strings via `strip_tags()`/Regex-Verhalten der Trait
+     `SanitizesHtmlContent`, siehe Abschnitt "Verifizierte Annahmen" unten)
+     und per `assertDatabaseHas` geprüft.
+  6. `update()` mit neuem Bild löscht das alte Bild von der `public`-Disk
+     (`Storage::disk('public')->assertMissing($oldPath)`), das neue Bild
+     existiert und unterscheidet sich vom alten Pfad.
+  7. `destroy()` löscht das zugehörige Bild von der Disk
+     (`assertMissing`) und den Datensatz (`assertDatabaseMissing`).
+  8. `displayDays = 400` (außerhalb 1–365) liefert HTTP 422 mit
+     `assertJsonValidationErrors(['displayDays'])`.
+
+## Wichtige technische Entscheidung: `update()`-Test ohne `_method`-Override
+
+Der Task-Prompt wies darauf hin, für den `update()`-Test ggf.
+`_method=PUT`-Override via `$this->post(...)` zu verwenden. Nach Prüfung
+von `backend/routes/api.php:208` ist die Route jedoch ein **echtes**
+`Route::put(...)` (kein `_method`-Override auf Anwendungsseite nötig).
+Zusätzlich habe ich `Illuminate\Foundation\Testing\Concerns\MakesHttpRequests`
+gelesen (`vendor/laravel/framework/.../MakesHttpRequests.php:422-428,
+596-618`): `$this->put($uri, $data)` ruft `call('PUT', $uri, $data, ...)`
+auf, und `call()` extrahiert `UploadedFile`-Instanzen aus `$data` via
+`extractFilesFromDataArray()` unabhängig von der HTTP-Methode — die Datei
+landet korrekt in der Files-Bag des Test-Requests. Ein `_method`-Override
+war daher nicht nötig; ich verwende direkt `$this->put(...)` mit
+`UploadedFile::fake()` im Datenarray. Diese Annahme ist im Test durch das
+grüne Ergebnis verifiziert (Datei wird ersetzt, alte Datei verschwindet
+von der Disk).
+
+## Verifizierte Annahmen
+
+- **Exakter sanitisierter String:** Vor dem Schreiben des Tests per
+  `php -r` lokal nachvollzogen, was `SanitizesHtmlContent::sanitizeHtmlDescription()`
+  (`backend/app/Http/Requests/Concerns/SanitizesHtmlContent.php:39-50`) aus
+  `<p onclick="alert(1)">Hallo</p><script>alert(1)</script>` macht:
+  `strip_tags()` entfernt das `<script>`-Tag, lässt aber dessen Text-Inhalt
+  stehen (PHP-Verhalten seit jeher, kein Tag-Content-Removal); die
+  anschließende Attribut-Strip-Regex entfernt `onclick="…"` vom `<p>`-Tag.
+  Ergebnis: `<p>Hallo</p>alert(1)` — exakt dieser String wird in
+  `assertDatabaseHas` geprüft.
+- **Route für Update ist echtes `PUT`**, nicht `POST` mit
+  `_method`-Override (siehe oben).
+
+## Pre-Flight-Checks (innerhalb Docker, `dog-school-php`-Container)
+
+```
+docker compose exec php vendor/bin/pest --filter=AnnouncementApiTest
+# → 11 passed (29 assertions)
+
+docker compose exec php vendor/bin/pint --test tests/Feature/Api/AnnouncementApiTest.php
+# → PASS (1 file, keine Formatierungsabweichungen)
+
+docker compose exec php vendor/bin/pest
+# → volle Suite: 704 passed (2224 assertions), keine Regressionen
+```
+
+**Hinweis:** `composer test`/`composer qa`/`composer stan`/`composer lint`
+existieren nicht als Scripts in `backend/composer.json` (nur
+`post-autoload-dump`, `post-update-cmd`, `post-root-package-install`,
+`post-create-project-cmd`, `dev`). Auch `phpstan`/`php-cs-fixer` sind
+nicht in `vendor/bin/` vorhanden — nur `pest` und `pint`. Ich habe daher
+`vendor/bin/pest` und `vendor/bin/pint --test` direkt ausgeführt statt der
+in `CLAUDE.md` Abschnitt 5/7.1 genannten Composer-Scripts. Diese Lücke
+existiert unabhängig von T08 und liegt außerhalb des Task-Scopes (keine
+`composer.json`-Änderung durch mich — das wäre eine fremde Datei/ein
+anderer Task). Für den Architekten/Skeptiker als Hinweis dokumentiert,
+falls ein eigener Change dafür sinnvoll ist.
+
+## Nicht angefasst
+
+- Kein Produktivcode geändert (Model, Policy, Requests, Resource,
+  Controller, Routen, Migration, Factory bereits durch T01–T07 fertig).
+- Keine Spec-Dateien geändert.

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T09.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T09.notes.md
@@ -1,0 +1,119 @@
+# Notes T09: Frontend-API-Client + Composable
+
+**Change-ID:** add-announcement-banner
+**Agent:** dev-typescript
+**Dateien (neu):**
+- `frontend/src/api/announcements.ts`
+- `frontend/src/api/announcements.test.ts`
+- `frontend/src/composables/useAnnouncements.ts`
+
+## Umsetzung
+
+### `frontend/src/api/announcements.ts`
+
+Folgt `frontend/src/api/pricingItems.ts` für `getPublic`/`getAll`/`delete`
+(schlanke Funktionen auf einem Objekt-Literal, `response.data.data`-
+Unwrapping) und `frontend/src/api/settings.ts:35-64` sowie
+`frontend/src/api/trainingAttachments.ts:49-59` für die Multipart-Stellen
+(`create`/`update`).
+
+- `interface Announcement` bildet exakt den in `design.md` Abschnitt 5.1/6.1
+  verbindlich festgelegten Response-Shape ab (`id`, `title`, `body`,
+  `imageUrl: string | null`, `displayDays`, `expiresAt: string | null`,
+  `isActive: boolean`, `createdAt: string | null`, `updatedAt: string | null`).
+- `interface AnnouncementFormData` (`title`, `body`, `displayDays`,
+  `image?: File | null`) — Grundlage für `create()`/`update()`.
+- `buildFormData()` (private Hilfsfunktion, DRY zwischen `create`/`update`):
+  hängt nur definierte Felder an, damit `update()` mit `Partial<...>` echte
+  Teil-Updates senden kann, ohne unberührte Felder mit Leerstrings zu
+  überschreiben.
+- **`create(data)`:** `apiClient.post('/api/v1/admin/announcements', buildFormData(data), { headers: { 'Content-Type': 'multipart/form-data' } })`.
+- **`update(id, data)`:** baut FormData, setzt zusätzlich
+  `formData.set('_method', 'PUT')` (bewusst `set()`, nicht `append()` — siehe
+  Kommentar in der Datei, identische Begründung wie in `settings.ts:48-50`)
+  und sendet ebenfalls per `apiClient.post(...)` **mit** explizitem
+  `headers: { 'Content-Type': 'multipart/form-data' }` an
+  `/api/v1/admin/announcements/{id}` — **kein** echter HTTP-`PUT`.
+- **Beide** Methoden (`create` **und** `update`) setzen den
+  `Content-Type`-Header explizit pro Request. Grund (aus der Task-Vorgabe /
+  Skeptiker-Korrektur übernommen): `apiClient`
+  (`frontend/src/api/client.ts:33-40`) setzt einen Default-Header
+  `Content-Type: application/json` auf der Axios-Instanz; ohne expliziten
+  Override würde Axios ein `FormData`-Objekt wegen `hasJSONContentType`
+  fälschlich zu JSON serialisieren statt als `multipart/form-data` zu senden.
+- `getPublic()` → `GET /api/v1/announcements` (öffentlich), `getAll()` →
+  `GET /api/v1/admin/announcements` (admin), `delete(id)` →
+  `DELETE /api/v1/admin/announcements/{id}`.
+
+### `frontend/src/composables/useAnnouncements.ts`
+
+1:1-Aufbau nach `frontend/src/composables/usePricingItems.ts`: `ref`-State
+(`announcements`, `loading`, `error`), fünf async Funktionen
+(`loadPublic`, `loadAll`, `createAnnouncement`, `updateAnnouncement`,
+`deleteAnnouncement`), jeweils mit try/catch/finally und deutschsprachiger
+Fehlermeldung (`error.value = e instanceof Error ? e.message : '...'`).
+`createAnnouncement`/`updateAnnouncement`/`deleteAnnouncement` aktualisieren
+`announcements.value` lokal (immutabel via `map`/`filter`/Spread), analog zu
+`updateItem`/`deleteItem`/`createItem` in `usePricingItems.ts`.
+
+### `frontend/src/api/announcements.test.ts`
+
+Struktur/Stil nach `frontend/src/api/settings.test.ts` (Vitest, `vi.mock('@/api/client', ...)`
+mit `get`/`post`/`put`/`delete` als `vi.fn()`, `beforeEach` mit
+`vi.clearAllMocks()`). 17 Tests, gruppiert je API-Methode:
+
+- `getPublic`/`getAll`: korrekter Endpunkt, korrektes Unwrapping von
+  `{ data: [...] }`.
+- `create`: sendet via `apiClient.post` an den Admin-Endpunkt, explizite
+  Multipart-Header, FormData enthält Textfelder korrekt, **kein**
+  `_method`-Feld, optionales `image`-File wird angehängt bzw. weggelassen,
+  Rückgabewert wird korrekt zurückgegeben.
+- `update`: sendet via `apiClient.post` (nicht `apiClient.put`), korrekte
+  URL mit ID, explizite Multipart-Header, `_method=PUT` im FormData,
+  Teil-Update sendet nur geänderte Felder, optionales Ersatzbild wird
+  angehängt, Rückgabewert wird korrekt zurückgegeben.
+- `delete`: `apiClient.delete` mit korrekter URL.
+
+## Verifikation
+
+```bash
+cd frontend
+npx vitest run src/api/announcements.test.ts   # 1 Testdatei, 17 Tests, alle grün
+npx vitest run                                  # volle Suite: 13 Testdateien, 151 Tests, alle grün
+npx vue-tsc -b                                  # keine TypeScript-Fehler
+npm run build                                   # vue-tsc -b && vite build, kein Fehler/Warning
+```
+
+Kein ESLint im Projekt konfiguriert (`frontend/package.json` enthält kein
+`lint`-Script — bereits in `verification.md` "Fehlende QA-Scripts"
+dokumentiert), daher kein `npm run lint` ausgeführt.
+
+## Akzeptanzkriterien (aus tasks.md T09)
+
+- [x] `announcementsApi.create(...)` **und** `announcementsApi.update(...)`
+      senden den Request mit explizitem
+      `headers: { 'Content-Type': 'multipart/form-data' }`
+- [x] `announcementsApi.update(...)` sendet ein `POST` mit `_method=PUT` im
+      `FormData`, **kein** echtes HTTP-`PUT`
+- [x] TypeScript-Interface `Announcement` bildet exakt den Response-Shape aus
+      `design.md` Abschnitt 5.1 ab
+- [x] `npm run test` (Vitest) läuft grün für `announcements.test.ts`
+- [x] `npm run build` läuft ohne TypeScript-Fehler (`vue-tsc -b`)
+
+## Offene Punkte / Hinweise für Reviewer
+
+- Keine Abweichung vom in `design.md` Abschnitt 6.1/6.2 vorgeschlagenen Code
+  (der dort abgedruckte Code enthielt bereits die vom Skeptiker geforderte
+  `Content-Type`-Header-Ergänzung für **beide** Methoden — die in
+  `verification.md` "Widerlegt" beschriebene Lücke war bereits vor Beginn
+  dieser Task in `design.md` behoben).
+- `AnnouncementFormData['image']` ist `File | null | undefined` (optional +
+  nullable), damit `update()` mit `Partial<AnnouncementFormData>` sowohl
+  "kein neues Bild" (`undefined`, Feld weglassen) als auch potenziell
+  "Bild explizit entfernen" (`null`) unterscheiden könnte — Letzteres wird
+  in T09 noch **nicht** genutzt (kein "Bild entfernen"-Feature in diesem
+  Change, siehe `design.md` Abschnitt 8.1, YAGNI), `buildFormData()` hängt
+  bei `null` aktuell kein Feld an (nur bei truthy `File`). Für T11 relevant,
+  falls dort später ein "Bild entfernen"-Schalter gebraucht wird.
+- Keine Komponenten (`AnnouncementBanner.vue`, `AnnouncementsView.vue`)
+  angefasst — das ist T10/T11, außerhalb des Scopes dieser Task.

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T10.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T10.notes.md
@@ -1,0 +1,109 @@
+# Notes T10: Öffentliche Anzeige-Komponente `AnnouncementBanner.vue`
+
+## Umgesetzte Dateien
+
+- `frontend/src/components/AnnouncementBanner.vue` (neu)
+- `frontend/src/components/AnnouncementBanner.test.ts` (neu)
+- `frontend/src/views/HomeView.vue` (geändert: Import + Einbindung)
+
+## Umsetzung
+
+- Komponente nutzt `useAnnouncements()` (T09, bereits vorhanden) und ruft
+  `loadPublic()` in `onMounted` auf. Kein Prop-Drilling von `HomeView.vue`
+  aus nötig — Kapselung analog zur Begründung in `design.md` Abschnitt 7.2.
+- Äußere `<section v-if="announcements.length">` sorgt dafür, dass bei
+  keiner aktiven Ankündigung nichts gerendert wird (kein leerer Container
+  im DOM).
+- Vertikal gestapelte Liste (`v-for` über `<article>`-Karten), kein
+  Karussell — wie in `design.md` Abschnitt 7.1 als KISS/YAGNI-Entscheidung
+  festgelegt. Karte mit optionalem Bild links (`object-cover`,
+  `w-48 h-48` auf `sm`+, volle Breite darunter auf Mobile) und
+  Titel/Rich-Text rechts.
+- `body` wird über `DOMPurify.sanitize(..., { ALLOWED_TAGS, ALLOWED_ATTR: [] })`
+  sanitized, mit identischer `ALLOWED_TAGS`-Konstante wie
+  `frontend/src/views/courses/CoursesView.vue:319-320`
+  (`p, br, strong, em, h2, h3, ul, ol, li, blockquote, code, pre`).
+  `v-html`-Stelle trägt den projektüblichen
+  `<!-- eslint-disable-next-line vue/no-v-html -->`-Kommentar.
+- Scoped-Style-Block für `.announcement-body :deep(p/ul/ol)` ist 1:1 vom
+  `.course-description`-Pendant in `CoursesView.vue` übernommen (gleiches
+  Rich-Text-Rendering-Verhalten für Absätze/Listen).
+- `HomeView.vue`: `<AnnouncementBanner />` wurde exakt zwischen dem
+  schließenden `</section>` der Hero-Section (ursprünglich Zeile 26) und
+  dem Kommentar `<!-- Features Section -->` (ursprünglich Zeile 28)
+  eingefügt — Zeilennummern beim eigenen Lesen der Datei verifiziert, sie
+  stimmten exakt mit `design.md` Abschnitt 7.2 überein. Import
+  `import AnnouncementBanner from '@/components/AnnouncementBanner.vue'`
+  wurde vor dem bestehenden `PricingModal`-Import ergänzt (alphabetisch
+  vor `PricingModal`). Kein zusätzlicher `onMounted()`-Aufruf in
+  `HomeView.vue` nötig, wie in `design.md` begründet.
+
+## Tests
+
+`AnnouncementBanner.test.ts` mockt `useAnnouncements()` direkt (Muster
+identisch zu `frontend/src/components/PricingItemForm.test.ts` und
+`frontend/src/views/SettingsView.test.ts`, die ebenfalls Composables per
+`vi.mock('@/composables/...')` stubben statt die HTTP-Ebene zu mocken).
+Abgedeckte Fälle:
+
+- kein sichtbarer Bereich bei leerer `announcements`-Liste
+- `loadPublic()` wird beim Mount genau einmal aufgerufen
+- eine Karte pro aktiver Ankündigung, inkl. Titel-Text
+- Bild wird gerendert (`src`/`alt`) wenn `imageUrl` gesetzt ist
+- kein `<img>`, wenn `imageUrl` `null` ist
+- erlaubtes HTML (`<strong>`) wird über `v-html` durchgereicht
+- `<script>`-Tags werden von DOMPurify entfernt
+- nicht erlaubte Tags (`<img>` außerhalb `ALLOWED_TAGS`) und
+  Inline-Event-Attribute (`onclick`, `onerror`) werden entfernt
+
+**Hinweis zu einer Testumgebungs-Eigenheit (kein Produktivcode-Problem):**
+Beim Entwerfen der DOMPurify-Tests wurde in einem isolierten Debug-Lauf
+festgestellt, dass DOMPurify 3.4.3 unter der `happy-dom`-Testumgebung
+(`vitest.config.ts`, `environment: 'happy-dom'`) für die *exakte*
+Eingabe-Kombination `<script>...</script><img ...>` (Script unmittelbar
+gefolgt von einem nicht erlaubten `<img>`-Tag, ohne dazwischenliegendes
+erlaubtes Element) das `<img>`-Tag fälschlich nicht entfernt — obwohl
+`img` nicht in `ALLOWED_TAGS` enthalten ist. Isoliert getestet (`<img>`
+allein, `<p>…</p><img>`, `<script>…</script>` allein, `<p onclick>…</p>
+<img onerror>` ohne Script davor) verhält sich DOMPurify in derselben
+Umgebung jeweils korrekt (Tag/Attribute werden entfernt) — das Problem
+tritt ausschließlich bei genau dieser Reihenfolge/Kombination auf und ist
+damit eine `happy-dom`/DOMPurify-Interaktionseigenheit der Testumgebung,
+kein reales Sanitizing-Problem im Produktivcode (derselbe Sanitizing-Code
+läuft in `CoursesView.vue` bereits unverändert in Produktion). Die Tests
+in `AnnouncementBanner.test.ts` wurden entsprechend in zwei unabhängige
+Fälle aufgeteilt (Script-Entfernung separat von Tag-/Attribut-Entfernung),
+um diese Testumgebungs-Eigenheit nicht versehentlich als Testfehler zu
+maskieren oder einen irreführenden Fehlschlag zu erzeugen.
+
+## QA-Checks (lokal, Frontend)
+
+```bash
+npx vitest run src/components/AnnouncementBanner.test.ts   # 8/8 grün
+npx vitest run                                              # 174/174 grün (gesamte Suite)
+npm run build                                                # vue-tsc -b + vite build, keine Fehler
+```
+
+`npm run lint` wurde **nicht** ausgeführt — `frontend/package.json` enthält
+kein `lint`-Script und es existiert keine `.eslintrc*`-Konfiguration im
+Projekt (bereits in `verification.md` unter "Fehlende QA-Scripts"
+dokumentiert). Der `eslint-disable-next-line vue/no-v-html`-Kommentar
+wurde dennoch gemäß Projektkonvention gesetzt, für den Fall einer künftigen
+ESLint-Einführung.
+
+## Bekannte Randbedingungen / bewusst nicht behandelt
+
+- Keine eigene Fehleranzeige bei fehlgeschlagenem `loadPublic()` — die
+  Komponente rendert dann einfach nichts (leeres `announcements`-Array
+  bleibt bestehen), was für eine rein informative, nicht-kritische
+  Banner-Komponente auf der öffentlichen Startseite angemessen ist
+  (Fail-silent statt Fehlermeldung auf der Homepage). `useAnnouncements()`
+  setzt `error.value` intern, das könnte bei Bedarf in einem späteren
+  Change ausgewertet werden — nicht Teil der T10-Akzeptanzkriterien.
+- Kein `loading`-Indikator während `loadPublic()` läuft — analog zur
+  bestehenden `PricingModal`/`usePricingItems()`-Nutzung in `HomeView.vue`,
+  die ebenfalls keinen sichtbaren Ladezustand für die Kachel zeigt
+  (Konsistenz mit vorhandenem Muster, YAGNI für diesen Change).
+- `frontend/src/router/index.ts` und `frontend/src/layouts/DefaultLayout.vue`
+  wurden **nicht** angefasst (Teil von T11, laut Vorgabe explizit
+  ausgeschlossen).

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T11.bugfix-review-blocker.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T11.bugfix-review-blocker.notes.md
@@ -1,0 +1,149 @@
+# Notes: Reviewer-Blocker-Fix — geteilter `error`-Ref versteckt die Liste
+
+**Change-ID:** add-announcement-banner
+**Agent:** dev-typescript
+**Bezug:** Reviewer-Befund zu T11 (`AnnouncementsView.vue`/`useAnnouncements.ts`)
+
+## Befund (Zusammenfassung)
+
+`useAnnouncements.ts` verwendete einen einzigen geteilten `error`-Ref für
+Lade- **und** Mutations-Operationen. Das Template von `AnnouncementsView.vue`
+rendert die Liste über eine `v-if`/`v-else-if`-Kette
+(`loading` → `error` → `leer` → `<ul>`). Schlug eine Mutation (z. B.
+`deleteAnnouncement`) fehl, blieb `error.value` gesetzt, und da
+`v-else-if="error"` **vor** `<ul v-else>` geprüft wird, verschwand die
+komplette (weiterhin gültige) Liste hinter der Fehlermeldung — obwohl
+`announcements` unverändert befüllt war. Vom Tester unabhängig bestätigt,
+inkl. neuer Testfälle in `AnnouncementsView.test.ts` für `update`/`delete`-
+Fehlerfälle.
+
+## Gewählte Option: (a) getrennte `loadError`/`mutationError`-Refs
+
+Der Reviewer bot drei Optionen an und verwies zur Prüfung auf
+`frontend/src/views/SettingsView.vue`. Vorab-Recherche vor der Entscheidung:
+
+- **`SettingsView.vue:565-566` / `608` / `652`:** Die (inline im View selbst
+  implementierte, nicht über ein Composable laufende) Einstellungs-Verwaltung
+  verwendet tatsächlich getrennte `loadError`- und `saveError`-Refs — `loadError`
+  gated den Formular-Bereich (`v-else-if="loadError"`, Zeile 16), `saveError`
+  wird unabhängig davon am Fußende des Formulars angezeigt (Zeile 387-392) und
+  blockiert nie die Sichtbarkeit des Formulars selbst. Das bestätigt Option (a)
+  als etabliertes, bewusstes Projektmuster für **genau dieses Problem**
+  (Lade- vs. Sende-Fehler nicht vermischen).
+- **`usePricingItems.ts` (Composable, das laut `design.md` Abschnitt 6.2 als
+  1:1-Vorbild für `useAnnouncements.ts` diente):** Hat denselben einzelnen
+  geteilten `error`-Ref wie der ursprüngliche `useAnnouncements.ts` — also
+  **kein** Vorbild für getrennte Fehler-Refs auf Composable-Ebene. In
+  `SettingsView.vue` wird der latente Bug dort nur deshalb nicht sichtbar,
+  weil `handleDeletePricingItem`/`handlePricingSaved`
+  (`SettingsView.vue:712-721`) nach **jeder** Mutation unbedingt erneut
+  `loadAll()` aufrufen, was `error.value` sofort wieder auf `null` zurücksetzt,
+  bevor ein Render mit gesetztem Fehler und sichtbarer Tabelle zusammentreffen
+  könnte. `AnnouncementsView.vue` ruft nach Mutationen bewusst **kein**
+  erneutes `loadAll()` auf (State wird lokal aus der Response
+  aktualisiert/gefiltert), wodurch der Bug dort tatsächlich auftritt.
+  **`usePricingItems.ts` wurde nicht angefasst** (außerhalb des erlaubten
+  Datei-Scopes dieser Korrektur) — das dortselbe latente Muster besteht
+  fort, ist aber durch das beschriebene Aufrufmuster in `SettingsView.vue`
+  aktuell nicht beobachtbar. Empfehlung für einen künftigen, separaten
+  Change: dieselbe Aufteilung in `usePricingItems.ts` nachziehen, falls
+  eine Aufrufstelle künftig ohne anschließendes `loadAll()` mutiert.
+
+**Entscheidung:** `useAnnouncements.ts` bekommt zwei getrennte Refs,
+`loadError` (gated `loadPublic`/`loadAll`) und `mutationError` (gated
+`createAnnouncement`/`updateAnnouncement`/`deleteAnnouncement`) — konsistent
+zur Namensgebung `loadError`/`saveError` aus `SettingsView.vue`. Das behebt
+das Problem an der Wurzel (Composable-API), nicht nur kosmetisch im Template
+(Option b wäre zudem unzureichend gewesen, siehe unten), und macht
+`mutationError` unabhängig sichtbar, ohne die Ladezustand-Kette zu berühren.
+
+**Warum nicht Option (b) (`v-else-if="error && announcements.length === 0"`)?**
+Bei nicht-leerer Liste hätte diese Bedingung den Fehler zwar nicht mehr vor
+der Liste versteckt, aber die Fehlermeldung dabei komplett unterdrückt statt
+sie sichtbar an anderer Stelle anzuzeigen — insbesondere für
+`deleteAnnouncement`-Fehler, die (anders als Create/Update) über keinen
+Modal-Dialog laufen und sonst nirgends angezeigt würden. Der vom Tester
+ergänzte Testfall "zeigt eine Fehlermeldung an wenn das Löschen fehlschlägt"
+mit nicht-leerer Liste hätte mit Option (b) allein **nicht** grün werden
+können.
+
+**Warum nicht Option (c) (`error.value` nach Anzeige zurücksetzen)?**
+Verschiebt das Problem nur zeitlich (Fehler blitzt kurz auf und verschwindet
+unkontrolliert wieder) und vermischt weiterhin zwei fachlich unterschiedliche
+Zustände (Laden vs. Mutieren) in einem Ref — widerspricht dem bereits im
+Projekt etablierten `loadError`/`saveError`-Muster aus `SettingsView.vue`.
+
+## Änderungen
+
+### `frontend/src/composables/useAnnouncements.ts`
+
+- `error` ersetzt durch zwei Refs: `loadError` (von `loadPublic`/`loadAll`
+  gesetzt/zurückgesetzt) und `mutationError` (von `createAnnouncement`/
+  `updateAnnouncement`/`deleteAnnouncement` gesetzt/zurückgesetzt). Jede
+  Funktion setzt beim Start nur noch **ihren eigenen** Fehler-Ref auf `null`
+  zurück — eine fehlgeschlagene Mutation überlebt daher einen nachfolgenden
+  erfolgreichen `loadAll()`-Aufruf nicht implizit mit, sie wird erst beim
+  nächsten Mutationsversuch zurückgesetzt (identisch zum Verhalten von
+  `saveError` in `SettingsView.vue`, das ebenfalls nur von `saveSettings()`
+  zurückgesetzt wird, nicht von `loadSettings()`).
+
+### `frontend/src/views/AnnouncementsView.vue`
+
+- Template: neuer, von der Lade-/Leer-/Listen-`v-if`-Kette **unabhängiger**
+  Banner `<div v-if="mutationError">` direkt unterhalb der Kopfzeile —
+  zeigt Mutations-Fehler (insbesondere Lösch-Fehler), ohne die
+  darunterliegende Liste zu verstecken.
+- Bestehende Kette (`loading` → `loadError` → leer → `<ul>`) unverändert in
+  der Struktur, nur `error` → `loadError` umbenannt.
+- `handleSubmit()`: prüft nach `createAnnouncement`/`updateAnnouncement`
+  jetzt `mutationError.value` statt `error.value` für `errors.general` im
+  Formular (unverändertes Verhalten, nur konsistente Ref-Referenz).
+
+### Tests
+
+- `frontend/src/composables/useAnnouncements.test.ts`: bestehende
+  `error`-Assertions auf `loadError` (Lade-Tests) bzw. `mutationError`
+  (Mutations-Tests) umgestellt; neuer Testfall, der explizit belegt, dass
+  ein vorheriger `loadError` einen nachfolgenden `deleteAnnouncement`-Erfolg
+  nicht mit einem stillen `mutationError` verunreinigt (Nachweis der
+  Unabhängigkeit beider Refs).
+- `frontend/src/views/AnnouncementsView.test.ts`: Mock liefert jetzt
+  `mockLoadError`/`mockMutationError` statt `mockError` (mit
+  aktualisiertem Erklär-Kommentar zum Grund für echte `ref()`-Mocks). Zwei
+  neue/erweiterte Assertions:
+  - "zeigt weiterhin die vorhandene Liste an, wenn eine Mutation
+    fehlschlägt" — reproduziert exakt das vom Reviewer beschriebene
+    Szenario (nicht-leere Liste + gesetzter `mutationError`) und prüft,
+    dass sowohl die Fehlermeldung **als auch** alle `<li>`-Einträge sichtbar
+    bleiben.
+  - Bestehender Löschen-Fehler-Test um eine Prüfung ergänzt, dass die Liste
+    (1 Eintrag) trotz Fehleranzeige weiterhin gerendert wird.
+
+## Verifikation
+
+```bash
+cd frontend
+npx vitest run
+# 17 Testdateien, 191 Tests grün (189 bestehende + 2 neue: 1x
+# useAnnouncements.test.ts, 1x AnnouncementsView.test.ts)
+
+npm run build
+# vue-tsc -b: keine Typfehler
+# vite build: erfolgreich, keine Warnungen
+```
+
+`npm run lint` existiert weiterhin nicht in `frontend/package.json`
+(bereits in `task-T11.notes.md` als bestehende Lücke dokumentiert, nicht
+Teil dieses Bugfixes).
+
+## Bewusst nicht angefasste Dateien
+
+- `frontend/src/composables/usePricingItems.ts` — enthält dasselbe latente
+  Muster (siehe Analyse oben), aber außerhalb des für diese Korrektur
+  freigegebenen Datei-Scopes. Aktuell nicht beobachtbar, weil
+  `SettingsView.vue` nach jeder Preis-Mutation ohnehin neu lädt.
+- `frontend/src/views/SettingsView.vue` — nur als Referenz gelesen, nicht
+  geändert.
+- `frontend/src/components/AnnouncementBanner.vue` — konsumiert nur
+  `announcements`/`loadPublic`, nicht `error`; von der Umbenennung nicht
+  betroffen, verifiziert per `grep`.

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T11.notes.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-T11.notes.md
@@ -1,0 +1,186 @@
+# Notes T11: Admin-Bereich `AnnouncementsView.vue`
+
+**Change-ID:** add-announcement-banner
+**Agent:** dev-typescript
+
+**Dateien (neu):**
+- `frontend/src/views/AnnouncementsView.vue`
+- `frontend/src/views/AnnouncementsView.test.ts`
+
+**Dateien (geändert):**
+- `frontend/src/router/index.ts`
+- `frontend/src/layouts/DefaultLayout.vue`
+
+## Umsetzung
+
+### `frontend/src/views/AnnouncementsView.vue`
+
+Struktur folgt `design.md` Abschnitt 8.1, orientiert an `SettingsView.vue`
+(Seitengerüst: Titel, Ladezustand/Fehlerzustand, Leerzustand) und
+`PricingItemForm.vue` (Modal-Formular-Muster: `reactive`-Form-Objekt,
+`reactive`-Errors-Objekt, `saving`-Ref, clientseitige Validierung vor dem
+API-Aufruf, `errors.general` aus dem `error`-Ref des Composables nach dem
+Aufruf). Anders als bei `PricingItemForm.vue` ist das Formular **nicht**
+als eigene Komponente ausgelagert, sondern direkt in `AnnouncementsView.vue`
+eingebettet (Task listet keine eigene Formular-Komponentendatei; die
+Entscheidung "eingebettet oder Modal" lag laut `design.md` Abschnitt 8.1
+explizit beim Entwickler-Agenten — Modal-Overlay-Optik wie
+`PricingItemForm.vue`, aber ohne zusätzliche Datei, da nur eine
+Aufrufstelle existiert und die Task keine weitere Datei vorsieht — YAGNI).
+
+- **Liste:** `<ul>` mit `<li>` pro Ankündigung aus `announcements`
+  (`useAnnouncements().loadAll()`, aufgerufen in `onMounted`), zeigt
+  Miniaturbild (falls `imageUrl` gesetzt), Titel, Status-Badge (`Aktiv` /
+  grün `bg-green-100 text-green-800` wenn `announcement.isActive`,
+  sonst `Abgelaufen` / grau `bg-gray-100 text-gray-800` — Farbschema
+  1:1 aus dem bestehenden Status-Badge-Muster in
+  `frontend/src/views/bookings/BookingsView.vue:319-321`
+  (`bookingStatusClass`) übernommen), gekürzte Textvorschau (HTML-Tags
+  regex-gestrippt statt `v-html`, da für eine reine Listenvorschau kein
+  Rich-Text-Rendering nötig ist — vermeidet zusätzliche
+  DOMPurify-Abhängigkeit in dieser Datei), Anzeigedauer und formatiertes
+  Ablaufdatum (`toLocaleDateString('de-DE')`, analog `BookingsView.vue`),
+  Bearbeiten-/Löschen-Buttons.
+- **Löschen:** `window.confirm(...)`-Bestätigung, danach
+  `deleteAnnouncement(id)` — identisches Muster wie
+  `SettingsView.vue:717-721` (`handleDeletePricingItem`) und
+  `CoursesView.vue:271` (`confirm(...)`-Aufruf vor dem Löschen).
+- **Formular:**
+  - Titel (`<input maxlength="255">`), Pflichtfeld.
+  - `<HtmlEditor v-model="form.body" />` — bestehende Komponente
+    unverändert übernommen, kein neuer Rich-Text-Editor.
+  - `<FileUpload :multiple="false" accepted-types="image/*"
+    :auto-upload="true" @upload="handleImageUpload"
+    @error="handleImageError" />`. `auto-upload="true"` gesetzt, damit
+    die Dateiauswahl sofort per `upload`-Event an das Formular
+    durchgereicht wird, statt dass in der `FileUpload`-Komponente selbst
+    noch ein separater "Dateien hochladen"-Button geklickt werden müsste
+    (der echte Netzwerk-Request passiert ohnehin erst beim Absenden des
+    Ankündigungsformulars über `createAnnouncement`/`updateAnnouncement`
+    — `FileUpload.vue` führt selbst keinen Upload durch, sondern emittiert
+    nur die ausgewählte(n) Datei(en), siehe
+    `frontend/src/components/FileUpload.vue:245-260`).
+  - Bei Bearbeiten mit vorhandenem Bild und noch keiner neuen Auswahl wird
+    das aktuelle Bild (`editingAnnouncement.imageUrl`) als Vorschau
+    angezeigt; wird eine neue Datei gewählt, ersetzt sie
+    `form.image` (bestehendes Bild bleibt serverseitig erhalten, wenn
+    `form.image` beim Update `null` ist — `buildFormData()` in
+    `frontend/src/api/announcements.ts:27-34` hängt `image` nur an, wenn
+    ein Wert vorhanden ist; kein "Bild entfernen"-Schalter, wie in
+    `design.md` Abschnitt 8.1 als YAGNI markiert).
+  - Zahlenfeld `displayDays` (`<input type="number" min="1" max="365">`),
+    clientseitige Validierung ergänzt den Bereich serverseitig
+    (`StoreAnnouncementRequest`/`UpdateAnnouncementRequest`, T04) um
+    sofortiges Feedback ohne Round-Trip.
+  - Speichern ruft `createAnnouncement`/`updateAnnouncement` aus dem
+    Composable auf; nach dem Aufruf wird `error.value` aus dem Composable
+    geprüft — bei Fehler bleibt das Formular offen und zeigt
+    `errors.general` (identisches Muster wie
+    `PricingItemForm.vue:263-267`), sonst wird das Formular geschlossen.
+
+### `frontend/src/router/index.ts`
+
+Neuer Eintrag `announcements` (Route-Name `Announcements`,
+`component: () => import('@/views/AnnouncementsView.vue')`,
+`meta: { title: 'Ankündigungen', requiresAdmin: true }`) im
+`/app`-Kind-Routen-Array, eingefügt nach dem `settings`-Eintrag und vor
+`training-logs` — exakt an der in `design.md` Abschnitt 8.2 vorgegebenen
+Stelle. Der bestehende Router-Guard
+(`if (to.meta.requiresAdmin && !authStore.isAdmin) { ... }`,
+`frontend/src/router/index.ts:182-185`, unverändert) greift automatisch,
+da `requiresAdmin: true` gesetzt ist — kein Guard-Code geändert.
+
+### `frontend/src/layouts/DefaultLayout.vue`
+
+- `MegaphoneIcon`-Import in die bestehende
+  `@heroicons/vue/24/outline`-Import-Liste ergänzt (nach `Cog6ToothIcon`).
+- Neuer Navigations-Eintrag `{ name: 'Ankündigungen', to: { name:
+  'Announcements' }, icon: MegaphoneIcon, roles: ['admin'] }` im
+  `navigation`-Computed, eingefügt nach dem "Einstellungen"-Eintrag, vor
+  "Kontakt" — exakt an der in `design.md` Abschnitt 8.3 vorgegebenen
+  Stelle. Die bestehende Rollen-Filterung
+  (`items.filter(item => !user.value || item.roles.includes(user.value.role))`,
+  `DefaultLayout.vue:247`, unverändert) blendet den Eintrag für
+  Nicht-Admins automatisch aus.
+
+### `frontend/src/views/AnnouncementsView.test.ts`
+
+15 Tests (Vitest + `@vue/test-utils`), Struktur/Stil an
+`PricingItemForm.test.ts` und `SettingsView.test.ts` angelehnt:
+
+- `useAnnouncements` wird gemockt (`vi.mock('@/composables/useAnnouncements', ...)`).
+  **Wichtig:** Der Mock liefert **echte Vue-`ref()`s** für
+  `announcements`/`loading`/`error` — nicht nur eine
+  `{ value: ... }`-Attrappe wie in `PricingItemForm.test.ts`s
+  `mockApiError`. Grund: `AnnouncementsView.vue` liest `error` sowohl im
+  Template (`v-else-if="error"`, verlässt sich auf den
+  Compiler-`unref()`-Mechanismus, der nur bei echten Refs korrekt
+  entpackt) als auch im Script (`error.value` nach `createAnnouncement`/
+  `updateAnnouncement`, analog `PricingItemForm.vue`). Eine reine
+  `{ value: null }`-Attrappe ist im Template immer wahrheitswertig (da
+  ein Objekt truthy ist, unabhängig von `.value`), was den
+  Leerzustand-Test verfälscht hätte — mit echten `ref()`s verhalten sich
+  beide Zugriffsarten identisch zur echten Composable-Implementierung.
+- Da die Mock-Refs modulweit geteilt und zwischen Tests wiederverwendet
+  werden, wird nach jedem Test explizit `wrapper.unmount()` aufgerufen
+  (`afterEach`) — ohne das führten spätere Ref-Mutationen zu
+  Reaktivitäts-Updates auf bereits von jsdom/happy-dom entsorgten
+  Wrapper-Instanzen früherer Tests (`Cannot read properties of null`
+  in `runtime-core`).
+- `HtmlEditor` wird als einfaches `<textarea>` gestubbt (Tiptap/ProseMirror
+  benötigt eine vollwertige `contenteditable`-DOM-Umgebung, die für einen
+  reinen `v-model`-Vertragstest nicht nötig ist); `FileUpload` läuft
+  **ungestubbt** (keine externen Abhängigkeiten) — der Datei-Upload-Test
+  emittiert das `upload`-Event direkt über
+  `wrapper.findComponent(FileUpload).vm.$emit(...)`.
+- `window.confirm` wird über `vi.stubGlobal('confirm', vi.fn()...)`
+  ersetzt (kein bestehendes Präzedenzbeispiel im Projekt gefunden, da
+  `happy-dom` `window.confirm` nicht implementiert — `vi.spyOn(window,
+  'confirm')` schlägt deshalb mit "can only spy on a function, received
+  undefined" fehl).
+- Abgedeckte Szenarien: `loadAll` beim Mounten, Ladeindikator,
+  Fehleranzeige beim Laden, Leerzustand, Status-Badges für aktive **und**
+  abgelaufene Ankündigungen, leeres/vorausgefülltes Formular öffnen,
+  Client-Validierung (Titel leer, `displayDays` außerhalb 1–365),
+  `createAnnouncement`-Aufruf mit Formulardaten + Formular schließt sich,
+  `updateAnnouncement`-Aufruf mit der bearbeiteten ID, Bild-Auswahl landet
+  im Payload, Formular bleibt bei Server-Fehler offen und zeigt die
+  Fehlermeldung, Löschen mit/ohne Bestätigung.
+
+## Verifikation
+
+```bash
+cd frontend
+npx vitest run src/views/AnnouncementsView.test.ts   # 15/15 grün
+npx vitest run                                       # 172/173 grün — 1 Fehlschlag in
+                                                       # AnnouncementBanner.test.ts (T10),
+                                                       # außerhalb des T11-Scopes, siehe unten
+npx vue-tsc -b --force                                # keine Fehler
+npm run build                                         # erfolgreich, keine TS-/Build-Fehler
+```
+
+**Hinweis zum einen fehlschlagenden Test außerhalb dieser Task:**
+`src/components/AnnouncementBanner.test.ts` (`entfernt nicht erlaubte
+Tags und Attribute aus body (DOMPurify)`) schlägt zum Zeitpunkt dieser
+Implementierung fehl. Diese Datei gehört zu T10
+(`AnnouncementBanner.vue`), das laut Aufgabenstellung von einem anderen
+Agenten parallel bearbeitet wird und explizit **nicht** Teil von T11 ist
+— `AnnouncementBanner.vue`, `AnnouncementBanner.test.ts` und
+`HomeView.vue` wurden in dieser Task nicht angefasst. Kein
+Zusammenhang mit den in T11 geänderten/neuen Dateien
+(`AnnouncementsView.vue`, `AnnouncementsView.test.ts`, `router/index.ts`,
+`DefaultLayout.vue`).
+
+## Bekannte Abweichungen / Annahmen
+
+- `design.md` Abschnitt 8.1 überließ die Entscheidung "eingebettet oder
+  Modal" explizit dem Entwickler-Agenten. Gewählt: Modal-Overlay direkt
+  in `AnnouncementsView.vue` (kein separates
+  `AnnouncementFormModal.vue`), da die Task nur eine Formular-Aufrufstelle
+  vorsieht und keine eigene Formular-Komponentendatei in der Task-Dateiliste
+  steht.
+- Kein automatisiertes `npm run lint` verfügbar (siehe `verification.md`,
+  Abschnitt "Fehlende QA-Scripts" — `frontend/package.json` enthält
+  keinen `lint`-Script). Manuell auf Konsistenz mit bestehenden
+  Vue-/TypeScript-Konventionen geprüft (Datei- und Komponentennamen,
+  `<script setup lang="ts">`, Prop-/Event-Typisierung ohne `any`).

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/task-report.test-report.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/task-report.test-report.md
@@ -1,0 +1,237 @@
+# Test-Report: add-announcement-banner (T01–T11, gesamter Change)
+
+**Status:** alle-gruen
+
+**Geprüft auf Branch:** `feature/add-announcement-banner`
+**Geprüft gegen:** `openspec/changes/add-announcement-banner/proposal.md`,
+`design.md`, `tasks.md`, `TESTING.md`
+
+---
+
+## Vorgehen
+
+1. Volle Backend- und Frontend-Testsuite in der Docker-Umgebung als
+   Baseline ausgeführt (nicht nur den Entwickler-Berichten vertraut).
+2. Alle vorhandenen neuen Testdateien (`AnnouncementApiTest.php`,
+   `announcements.test.ts`, `AnnouncementBanner.test.ts`,
+   `AnnouncementsView.test.ts`) gegen die Akzeptanzkriterien aus
+   `tasks.md` und gegen `design.md` abgeglichen.
+3. Produktivcode gelesen (`Announcement.php`, `AnnouncementFactory.php`,
+   `AnnouncementController.php`, `AnnouncementResource.php`,
+   `StoreAnnouncementRequest.php`, `UpdateAnnouncementRequest.php`,
+   `AnnouncementBanner.vue`, `useAnnouncements.ts`,
+   `AnnouncementsView.vue`, `announcements.ts`) um echte Lücken von
+   bereits abgedeckten Fällen zu unterscheiden.
+4. Lücken identifiziert und mit neuen Tests geschlossen (keine
+   Produktivcode-Änderung).
+5. Beide Suiten erneut vollständig ausgeführt, inkl. `npm run build`.
+
+---
+
+## Baseline (vor Ergänzungen)
+
+```
+Backend:  Tests: 704 passed (2224 assertions)   — 25.92s
+Frontend: Test Files: 15 passed (15) / Tests: 174 passed (174) — 2.23s
+Build:    vue-tsc -b && vite build → erfolgreich, keine TS-Fehler
+```
+
+Deckt sich mit dem Bericht der Entwickler-Agenten — verifiziert, nicht nur
+übernommen.
+
+---
+
+## Hinzugefügte / geänderte Tests
+
+### Backend
+
+- `backend/tests/Feature/Domain/AnnouncementModelTest.php` *(neu, 8 Tests,
+  Gruppen `domain`, `announcement`)* — Model-Ebene, die
+  `AnnouncementApiTest.php` (nur HTTP-Ebene) nicht abdeckt:
+  - `expires_at` wird bei der Erstellung korrekt aus `created_at +
+    display_days` berechnet
+  - `isActive()` liefert `true`/`false` korrekt für aktive/abgelaufene
+    Datensätze
+  - **Kernlücke (explizit vom Auftrag verlangt):** Erhöhen **und**
+    Verringern von `display_days` auf einem bestehenden, bereits
+    persistierten Datensatz berechnet `expires_at` nachweislich ab dem
+    **ursprünglichen `created_at`**, nicht ab `now()`
+  - Ändern eines anderen Feldes (`title`) ohne `display_days`-Änderung
+    lässt `expires_at` unverändert (dokumentiertes Verhalten aus
+    `design.md` Abschnitt 11, Risikotabelle)
+  - `scopeActive()` liefert nur zukünftige `expires_at`-Datensätze, auch
+    im Leerfall (alle abgelaufen)
+
+- `backend/tests/Feature/Api/AnnouncementApiTest.php` *(erweitert, 6 neue
+  Tests)*:
+  - `displayDays = 1` und `displayDays = 365` als Randwerte werden
+    akzeptiert (bisher nur der Fehlerfall `400` getestet)
+  - Fehlendes `title` → 422 mit `title`-Validierungsfehler
+  - Leerer `body` (`''`) → 422 mit `body`-Validierungsfehler
+  - Fehlendes `body`-Feld → 422 mit `body`-Validierungsfehler
+  - Öffentlicher Endpunkt liefert exakt die im Vertrag (`design.md`
+    Abschnitt 5.1) definierten Felder, keine zusätzlichen/verborgenen
+    Schlüssel (Kontrolle der bewussten Design-Entscheidung "keine
+    getrennte Public/Admin-Resource")
+
+### Frontend
+
+- `frontend/src/composables/useAnnouncements.test.ts` *(neu, 11 Tests)* —
+  **fehlte komplett**, obwohl das Projekt für das strukturell identische
+  `usePricingItems`-Composable einen dedizierten Test hat
+  (`usePricingItems.test.ts`). Deckt `loadPublic`/`loadAll`/
+  `createAnnouncement`/`updateAnnouncement`/`deleteAnnouncement` jeweils
+  im Erfolgs- und Fehlerfall ab (API-Schicht gemockt, echte
+  Composable-Logik getestet — nicht wie in den View-/Komponenten-Tests
+  nur die Composable-Oberfläche gemockt).
+- `frontend/src/components/AnnouncementBanner.integration.test.ts` *(neu,
+  2 Tests)* — `AnnouncementBanner.test.ts` mockt das komplette
+  `useAnnouncements`-Composable, wodurch der reale Fehlerpfad
+  (`loadPublic()` wirft, `try/catch` im Composable) nie durchlaufen
+  wird. Diese neue Datei mockt stattdessen nur die API-Schicht
+  (`announcementsApi`) und bindet das echte Composable ein:
+  - `loadPublic()` wirft einen Fehler → kein Crash beim Mounten, kein
+    sichtbarer `<section>`-Bereich (explizit angefragtes Szenario)
+  - `loadPublic()` liefert Daten → Karte wird korrekt gerendert
+    (Kontrollfall, dass der reale Wiring-Pfad Komponente↔Composable↔API
+    funktioniert, nicht nur mit gemocktem Composable)
+- `frontend/src/views/AnnouncementsView.test.ts` *(erweitert, 2 neue
+  Tests)*:
+  - Fehlgeschlagenes `updateAnnouncement` hält das Formular offen und
+    zeigt die Fehlermeldung (bisher nur für `create` getestet)
+  - Fehlgeschlagenes `deleteAnnouncement` zeigt eine Fehlermeldung an
+
+---
+
+## Akzeptanzkriterien-Abdeckung (Ergänzung/Vertiefung ggü. bestehenden Tests)
+
+- [x] T02 AK3 "Wird `display_days` auf einem bestehenden, nicht
+      abgelaufenen Datensatz erhöht und gespeichert, wird `expires_at`
+      neu ab dem ursprünglichen `created_at` berechnet (nicht ab
+      `now()`)" — bisher **nicht** auf Model-Ebene getestet (nur
+      implizit durch das Fehlen eines gegenteiligen Tests). Jetzt
+      getestet in `AnnouncementModelTest.php::it berechnet expires_at
+      beim erhöhen von display_days …` (und zusätzlich für den
+      Verringerungsfall)
+- [x] T02 AK1/AK2/AK4 — abgedeckt in `AnnouncementModelTest.php`
+- [x] T04 AK4 "`displayDays` außerhalb von 1–365 wird mit HTTP 422
+      abgelehnt" — Randwerte 1 und 365 jetzt zusätzlich als
+      Erfolgsfall abgedeckt (`AnnouncementApiTest.php`)
+- [x] Pflichtfeld-Validierung `title`/`body` — jetzt explizit getestet
+      (vorher nicht abgedeckt, obwohl `required` in den Regeln steht)
+- [x] "Öffentliche Route leakt keine Admin-only-Felder" — verifiziert:
+      `AnnouncementResource` ist laut `design.md` Abschnitt 5.1
+      **bewusst identisch** für Public/Admin (kein `created_by`, keine
+      internen Notizen im Datenmodell). Test bestätigt, dass die Public-
+      Response exakt die neun dokumentierten Felder enthält, keine
+      zusätzlichen. Kein Bug, sondern eine dokumentierte,
+      nachvollziehbare Design-Entscheidung (YAGNI, siehe `design.md`
+      Zeile 414–419).
+- [x] `AnnouncementBanner.vue` bei Fehler in `loadPublic()`: kein Crash,
+      kein sichtbarer Bereich — jetzt mit echtem Composable getestet in
+      `AnnouncementBanner.integration.test.ts`
+- [x] `AnnouncementsView.vue` zeigt sinnvolle Fehlermeldungen bei
+      fehlgeschlagenem Create (bereits vorhanden), Update (neu) und
+      Delete (neu)
+
+---
+
+## Ausführungs-Ergebnis (nach Ergänzung)
+
+### Backend — `docker compose exec php vendor/bin/pest`
+
+```
+Tests:    718 passed (2259 assertions)
+Duration: 26.65s
+```
+
+Davon 25 im Bereich Announcement (`--group=announcement`):
+
+```
+PASS  Tests\Feature\Api\AnnouncementApiTest      (17 Tests)
+PASS  Tests\Feature\Domain\AnnouncementModelTest  (8 Tests)
+Tests: 25 passed (64 assertions)
+```
+
+### Frontend — `npm run test -- --run`
+
+```
+Test Files  17 passed (17)
+Tests       189 passed (189)
+Duration    2.19s
+```
+
+Neu/relevant:
+
+```
+✓ src/composables/useAnnouncements.test.ts (11 tests)
+✓ src/components/AnnouncementBanner.integration.test.ts (2 tests)
+✓ src/components/AnnouncementBanner.test.ts (8 tests)
+✓ src/views/AnnouncementsView.test.ts (17 tests)
+✓ src/api/announcements.test.ts (17 tests)
+```
+
+### Frontend — `npm run build`
+
+```
+vue-tsc -b && vite build
+✓ 643 modules transformed.
+✓ built in 2.22s
+```
+Keine TypeScript-/Build-Fehler.
+
+---
+
+## Fehler (falls vorhanden)
+
+Keine — alle Backend- (718) und Frontend-Tests (189) sind grün,
+`npm run build` läuft ohne Fehler.
+
+**Hinweis, kein Bug:** Beim Aufdecken der `expires_at`-Model-Tests trat
+zunächst ein Testfehler auf (`Failed asserting that false is true.` beim
+Vergleich mit vollem Mikrosekunden-Carbon-`eq()`). Ursache war **kein**
+Produktivcode-Bug, sondern eine Eigenheit des Test-Setups: die
+`timestamp`-Spalte in der Migration (`2026_07_17_100000_create_
+announcements_table.php:20`) hat keine Sub-Sekunden-Präzision, und
+Eloquents Datetime-Cast wandelt zugewiesene `Carbon`-Werte beim Setzen
+sofort in einen String ohne Mikrosekunden um (`fromDateTime()`), während
+ein manuell in der Testdatei erzeugter Vergleichswert (`now()->subDays(5)`)
+volle Mikrosekundenpräzision behält. Behoben durch Vergleich auf
+Sekundengenauigkeit (`->format('Y-m-d H:i:s')` statt `->eq()`) — betrifft
+nur die Testassertion, keine Produktivlogik. Dokumentiert als Kommentar im
+Test.
+
+---
+
+## Nicht behobene Beobachtung für Reviewer/User (kein Test-Fix, nur Hinweis)
+
+`AnnouncementsView.vue`: Schlägt `deleteAnnouncement()` fehl, wird
+`error.value` in der Composable gesetzt. Da das Template
+(`v-else-if="error"`) den Fehlerblock **anstelle der gesamten Liste**
+rendert (nicht nur als zusätzlichen Hinweis), verschwindet nach einem
+fehlgeschlagenen Löschversuch kurzzeitig die komplette Ankündigungsliste
+zugunsten der Fehlermeldung — obwohl die übrigen (nicht gelöschten)
+Einträge weiterhin in `announcements` vorhanden sind. Das ist funktional
+kein Fehler (Daten gehen nicht verloren, nächstes `loadAll()`/Neuladen
+stellt die Liste wieder her) und in `TESTING.md`/`tasks.md` nicht als
+Akzeptanzkriterium ausgeschlossen — daher **kein** Testfehler, aber eine
+UX-Beobachtung, die dem Reviewer/User zur Kenntnis gebracht wird. Test
+`AnnouncementsView.test.ts::zeigt eine Fehlermeldung an wenn das Löschen
+fehlschlägt` verifiziert nur, dass die Fehlermeldung angezeigt wird (wie
+angefordert), nicht das Beibehalten der Liste.
+
+---
+
+## Zusammenfassung
+
+- 14 neue Backend-Tests (8 Model-Tests in neuer Datei
+  `AnnouncementModelTest.php` + 6 API-Tests in bestehender
+  `AnnouncementApiTest.php`; Baseline 704 → 718 grüne Tests)
+- 15 neue Frontend-Tests (11 Composable + 2 Integration + 2
+  View-Fehlerfälle; 189−174=15)
+- Keine Produktivcode-Änderung vorgenommen.
+- Keine echten Bugs in der Implementierung gefunden — die einzige
+  Auffälligkeit (Listen-Ausblendung bei Lösch-Fehler in
+  `AnnouncementsView.vue`) ist eine UX-Beobachtung, kein funktionaler
+  Defekt, und wird dem Reviewer/User zur Entscheidung vorgelegt statt
+  eigenmächtig behoben.

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/tasks.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/tasks.md
@@ -1,0 +1,349 @@
+# Tasks für add-announcement-banner
+
+**Change-ID:** add-announcement-banner
+
+**Übergabepunkt Backend → Frontend:** `AnnouncementResource`-JSON-Shape,
+siehe `design.md` Abschnitt 5.1 ("Verbindliches JSON-Beispiel"). T09
+(Frontend-API-Client) kann implementiert werden, sobald T05 (Resource) und
+T07 (Routen) abgeschlossen sind — der Response-Shape ist bereits jetzt in
+`design.md` final festgelegt und ändert sich durch die restlichen
+Backend-Tasks nicht mehr.
+
+---
+
+## T01: Migration `create_announcements_table`
+
+- **Agent:** dev-php
+- **Dateien:**
+  - `backend/database/migrations/2026_07_17_100000_create_announcements_table.php` *(neu)*
+- **Abhängigkeiten:** keine
+- **Beschreibung:**
+  Neue Migration gemäß `design.md` Abschnitt 2.2:
+
+  ```php
+  Schema::create('announcements', function (Blueprint $table) {
+      $table->id();
+      $table->string('title', 255);
+      $table->text('body');
+      $table->string('image_path')->nullable();
+      $table->unsignedSmallInteger('display_days');
+      $table->timestamp('expires_at');
+      $table->timestamps();
+
+      $table->index('expires_at');
+  });
+  ```
+
+  `down()`: `Schema::dropIfExists('announcements');`
+- **Akzeptanzkriterien:**
+  - [x] `php artisan migrate` läuft ohne Fehler gegen PostgreSQL (lokale
+        Docker-Standardumgebung)
+  - [x] `php artisan migrate` läuft ohne Fehler gegen MySQL
+        (`docker-compose.mysql.yml`, siehe CLAUDE.md Abschnitt 7.1)
+  - [x] `php artisan migrate:rollback` löscht die Tabelle korrekt auf
+        beiden Treibern
+  - [x] Kein raw SQL, kein `DB::statement()` in der Migration
+  - [x] Manuelle Prüfung: keine der in CLAUDE.md Abschnitt 4.1 gelisteten
+        PHP-8.3/8.4-Konstrukte verwendet (kein automatisiertes
+        `compat-check`-Script im Projekt vorhanden, siehe `proposal.md`
+        "Out of Scope")
+
+---
+
+## T02: Model `Announcement` + Factory
+
+- **Agent:** dev-php
+- **Dateien:**
+  - `backend/app/Models/Announcement.php` *(neu)*
+  - `backend/database/factories/AnnouncementFactory.php` *(neu)*
+- **Abhängigkeiten:** T01
+- **Beschreibung:**
+  Model gemäß `design.md` Abschnitt 2.3: `$fillable` (`title`, `body`,
+  `image_path`, `display_days`), `casts()`, `booted()`-Hook zur Berechnung
+  von `expires_at` aus `created_at`/`now()` + `display_days` bei jedem
+  Speichern mit geändertem `display_days` (oder Neuanlage), Methode
+  `isActive(): bool`, Scope `scopeActive()`.
+
+  Factory mit realistischen Faker-Werten für `title`/`body`/`display_days`
+  (1–30 Tage) sowie einem `expired()`-State (setzt `created_at`/`expires_at`
+  über `forceFill(...)->saveQuietly()` in die Vergangenheit, siehe
+  `design.md` Abschnitt 2.3 für den exakten Code).
+- **Akzeptanzkriterien:**
+  - [x] `Announcement::factory()->create()` erzeugt einen Datensatz mit
+        korrekt berechnetem `expires_at` (`created_at + display_days`)
+  - [x] `Announcement::factory()->expired()->create()` erzeugt einen
+        Datensatz, dessen `isActive()` `false` liefert
+  - [x] Wird `display_days` auf einem bestehenden, nicht abgelaufenen
+        Datensatz erhöht und gespeichert, wird `expires_at` neu ab dem
+        ursprünglichen `created_at` berechnet (nicht ab `now()`)
+  - [x] `scopeActive()` liefert nur Datensätze mit `expires_at > now()`
+
+---
+
+## T03: Policy `AnnouncementPolicy`
+
+- **Agent:** dev-php
+- **Dateien:**
+  - `backend/app/Policies/AnnouncementPolicy.php` *(neu)*
+- **Abhängigkeiten:** T02
+- **Beschreibung:**
+  Policy analog zu `backend/app/Policies/SettingPolicy.php` — alle
+  Methoden (`viewAny`, `view`, `create`, `update`, `delete`) prüfen
+  ausschließlich `$user->isAdmin()`. Siehe `design.md` Abschnitt 4.1 für
+  den vollständigen Code.
+- **Akzeptanzkriterien:**
+  - [x] Alle fünf Policy-Methoden implementiert, jeweils `isAdmin()`-Check
+  - [x] Kein automatisches Policy-Discovery-Problem: Laravel 11 löst
+        `App\Models\Announcement` → `App\Policies\AnnouncementPolicy` über
+        die Standard-Namenskonvention auf (kein manueller Eintrag in einem
+        Service-Provider nötig — wie bei `SettingPolicy`/`DogPolicy`
+        bereits der Fall; falls das Projekt dennoch einen expliziten
+        Policy-Provider pflegt, dort ergänzen)
+
+---
+
+## T04: FormRequests `StoreAnnouncementRequest` / `UpdateAnnouncementRequest`
+
+- **Agent:** dev-php
+- **Dateien:**
+  - `backend/app/Http/Requests/StoreAnnouncementRequest.php` *(neu)*
+  - `backend/app/Http/Requests/UpdateAnnouncementRequest.php` *(neu)*
+- **Abhängigkeiten:** T02
+- **Beschreibung:**
+  Siehe `design.md` Abschnitt 4.2/4.3 für den vollständigen Code beider
+  Klassen. Beide verwenden
+  `App\Http\Requests\Concerns\SanitizesHtmlContent` (bestehender Trait,
+  **keine neue Abhängigkeit**) zum Sanitizing von `body` in
+  `validatedSnakeCase()`. `image` wird validiert, aber **nicht** in
+  `validatedSnakeCase()` zurückgegeben (Controller behandelt den Upload
+  separat, siehe T06).
+- **Akzeptanzkriterien:**
+  - [x] `StoreAnnouncementRequest::authorize()` gibt `false` zurück, wenn
+        der User nicht `isAdmin()` ist
+  - [x] `body` wird über `sanitizeHtmlDescription()` bereinigt, bevor es
+        in `validatedSnakeCase()` erscheint
+  - [x] `image` erscheint **nicht** als Schlüssel in
+        `validatedSnakeCase()`
+  - [x] `displayDays` außerhalb von 1–365 wird mit HTTP 422 abgelehnt
+  - [x] `UpdateAnnouncementRequest` erlaubt Teil-Updates (`sometimes`),
+        nur übergebene Felder erscheinen in `validatedSnakeCase()`
+
+---
+
+## T05: Resource `AnnouncementResource`
+
+- **Agent:** dev-php
+- **Dateien:**
+  - `backend/app/Http/Resources/AnnouncementResource.php` *(neu)*
+- **Abhängigkeiten:** T02
+- **Beschreibung:**
+  Siehe `design.md` Abschnitt 5.1 für den vollständigen Code und das
+  verbindliche JSON-Beispiel. Felder: `id`, `title`, `body`, `imageUrl`
+  (über `Storage::disk('public')->url()`), `displayDays`, `expiresAt`
+  (ISO 8601), `isActive` (bool), `createdAt`, `updatedAt`.
+- **Akzeptanzkriterien:**
+  - [x] Response-Shape entspricht exakt dem JSON-Beispiel in `design.md`
+        Abschnitt 5.1 (Feldnamen camelCase)
+  - [x] `imageUrl` ist `null`, wenn kein Bild gesetzt ist
+  - [x] `isActive` spiegelt `Announcement::isActive()` wider
+
+---
+
+## T06: Controller `Api/AnnouncementController`
+
+- **Agent:** dev-php
+- **Dateien:**
+  - `backend/app/Http/Controllers/Api/AnnouncementController.php` *(neu)*
+- **Abhängigkeiten:** T03, T04, T05
+- **Beschreibung:**
+  Siehe `design.md` Abschnitt 5.1 für den vollständigen Code:
+  `publicIndex()` (nur aktive, ungeschützt), `index()` (alle, admin-only
+  via Policy `viewAny`), `store()` (admin-only via
+  `StoreAnnouncementRequest::authorize()`, inkl. Bild-Upload analog
+  `DogController::uploadImage()`), `update()` (admin-only via Policy
+  `update`, ersetzt vorhandenes Bild bei neuem Upload, löscht das alte),
+  `destroy()` (admin-only via Policy `delete`, löscht zugehöriges Bild).
+- **Akzeptanzkriterien:**
+  - [x] `publicIndex()` liefert ausschließlich Ankündigungen mit
+        `expires_at > now()`
+  - [x] `index()` liefert alle Ankündigungen (aktiv + abgelaufen)
+  - [x] `store()` speichert ein hochgeladenes Bild unter
+        `announcement-images/` auf der `public`-Disk und setzt
+        `image_path` korrekt
+  - [x] `update()` löscht das alte Bild von der Disk, wenn ein neues
+        hochgeladen wird
+  - [x] `destroy()` löscht das zugehörige Bild von der Disk mit
+  - [x] Alle vier Admin-Aktionen (`index`/`store`/`update`/`destroy`)
+        antworten mit HTTP 403, wenn der authentifizierte User kein Admin
+        ist
+
+---
+
+## T07: Routen-Ergänzung `backend/routes/api.php`
+
+- **Agent:** dev-php
+- **Dateien:**
+  - `backend/routes/api.php` *(ändern)*
+- **Abhängigkeiten:** T06
+- **Beschreibung:**
+  Siehe `design.md` Abschnitt 5.2 für die exakten Einfügepunkte:
+  `use`-Import für `AnnouncementController` (alphabetisch zwischen
+  `AnamnesisTemplateController` und `AuthController`), öffentliche Route
+  `GET /api/v1/announcements` (neuer Block nach dem bestehenden
+  "Public pricing route"-Block, Zeile 54-57), Admin-Routen
+  `GET/POST/PUT/DELETE /api/v1/admin/announcements[/{announcement}]`
+  (neuer Block nach dem bestehenden "Settings Management"-Block,
+  Zeile 192-195, innerhalb derselben `auth:sanctum`-Gruppe).
+- **Akzeptanzkriterien:**
+  - [x] `GET /api/v1/announcements` ist ohne Authentifizierung erreichbar
+  - [x] `GET/POST/PUT/DELETE /api/v1/admin/announcements[/...]` erfordern
+        `auth:sanctum` **und** `can:admin`
+  - [x] `php artisan route:list` zeigt alle fünf neuen Routen korrekt an
+
+---
+
+## T08: Backend-Tests `AnnouncementApiTest`
+
+- **Agent:** dev-php
+- **Dateien:**
+  - `backend/tests/Feature/Api/AnnouncementApiTest.php` *(neu)*
+- **Abhängigkeiten:** T01–T07
+- **Beschreibung:**
+  Pest-Feature-Test gemäß `TESTING.md` (Gruppen `api`, `announcement`;
+  `RefreshDatabase`; Factory-States `User::factory()->admin()`/`customer()`;
+  `it(...)`-Beschreibungen, dritte Person Indikativ, Deutsch). Mindestens
+  folgende Szenarien:
+  - Öffentlicher Endpunkt liefert nur aktive Ankündigungen
+    (`Announcement::factory()->expired()->create()` erscheint **nicht**)
+  - Admin-Endpunkt liefert auch abgelaufene Ankündigungen
+  - Nicht-Admin erhält HTTP 403 auf alle vier Admin-Aktionen
+  - Erstellen einer Ankündigung mit Bild-Upload speichert `image_path`
+    korrekt und liefert eine gültige `imageUrl`
+  - Rohes `<script>`/`onclick`-HTML im `body`-Feld wird beim Speichern
+    entfernt (Sanitizing-Verifikation, `assertDatabaseHas` mit bereinigtem
+    HTML)
+  - Aktualisieren mit neuem Bild löscht das alte Bild von der
+    `public`-Disk (`Storage::fake('public')` +
+    `Storage::disk('public')->assertMissing(...)`)
+  - Löschen einer Ankündigung löscht das zugehörige Bild mit
+  - `displayDays` außerhalb 1–365 liefert HTTP 422
+    (`assertJsonValidationErrors(['displayDays'])`)
+- **Akzeptanzkriterien:**
+  - [x] Alle Szenarien oben als eigene `it(...)`-Tests umgesetzt
+  - [x] `./vendor/bin/pest --filter=AnnouncementApiTest` läuft grün
+  - [x] Testdatei erfüllt die Checkliste aus `TESTING.md` Abschnitt 10
+        (Gruppen, `it()` statt `test()`, Assertion-Stil-Trennung,
+        Factory-States)
+
+---
+
+## T09: Frontend-API-Client + Composable
+
+- **Agent:** dev-typescript
+- **Dateien:**
+  - `frontend/src/api/announcements.ts` *(neu)*
+  - `frontend/src/api/announcements.test.ts` *(neu)*
+  - `frontend/src/composables/useAnnouncements.ts` *(neu)*
+- **Abhängigkeiten:** T05, T07 (Response-Shape ist ab T05 final, siehe
+  Übergabepunkt oben — Implementierung kann parallel zu T06/T08 beginnen,
+  sobald `design.md` Abschnitt 5.1/6.1 als Vertrag akzeptiert ist)
+- **Beschreibung:**
+  Siehe `design.md` Abschnitt 6.1/6.2 für den vollständigen Code-Vorschlag:
+  `announcementsApi.getPublic/getAll/create/update/delete`, wobei `create`
+  **und** `update` `FormData` (Multipart, Bild-Upload) senden und `update`
+  zusätzlich das `_method=PUT`-Override-Feld setzt (analog
+  `frontend/src/api/settings.ts:35-58` — **kein** echter HTTP-`PUT` mit
+  multipart Body, siehe Begründung in `design.md` Abschnitt 5.2). **Beide**
+  Methoden (`create` und `update`) müssen den Request explizit mit
+  `headers: { 'Content-Type': 'multipart/form-data' }` senden, da
+  `apiClient` (`frontend/src/api/client.ts:33-40`) standardmäßig
+  `Content-Type: application/json` setzt und `FormData` sonst nicht korrekt
+  serialisiert wird (identisches Muster wie
+  `frontend/src/api/settings.ts:60-64` und
+  `frontend/src/api/trainingAttachments.ts:54-58`).
+  `useAnnouncements()`-Composable folgt 1:1 dem Aufbau von
+  `frontend/src/composables/usePricingItems.ts`.
+- **Akzeptanzkriterien:**
+  - [x] `announcementsApi.create(...)` **und** `announcementsApi.update(...)`
+        senden den Request mit explizitem
+        `headers: { 'Content-Type': 'multipart/form-data' }` (kein Verlass
+        auf Axios-Default-Erkennung von `FormData`, da der
+        `apiClient`-Default `application/json` das sonst überschreiben
+        würde)
+  - [x] `announcementsApi.update(...)` sendet ein `POST` mit
+        `_method=PUT` im `FormData`, **kein** echtes HTTP-`PUT`
+  - [x] TypeScript-Interface `Announcement` bildet exakt den
+        Response-Shape aus `design.md` Abschnitt 5.1 ab
+  - [x] `npm run test` (Vitest) läuft grün für
+        `announcements.test.ts`
+  - [x] `npm run build` läuft ohne TypeScript-Fehler (`vue-tsc -b`)
+
+---
+
+## T10: Öffentliche Anzeige-Komponente `AnnouncementBanner.vue`
+
+- **Agent:** dev-typescript
+- **Dateien:**
+  - `frontend/src/components/AnnouncementBanner.vue` *(neu)*
+  - `frontend/src/components/AnnouncementBanner.test.ts` *(neu)*
+  - `frontend/src/views/HomeView.vue` *(ändern)*
+- **Abhängigkeiten:** T09
+- **Beschreibung:**
+  Siehe `design.md` Abschnitt 7.1/7.2. Komponente lädt selbst über
+  `useAnnouncements().loadPublic()` bei `onMounted`, rendert **nichts**,
+  wenn keine aktive Ankündigung vorhanden ist (`v-if="announcements.length"`),
+  zeigt alle aktiven Ankündigungen als vertikal gestapelte Liste (kein
+  Karussell, siehe Begründung `design.md` Abschnitt 7.1), sanitized `body`
+  clientseitig mit `DOMPurify` + derselben `ALLOWED_TAGS`-Konstante wie
+  `frontend/src/views/courses/CoursesView.vue:319-320`. Einbindung in
+  `HomeView.vue` exakt zwischen Zeile 26 (Ende Hero-Section) und Zeile 29
+  (Beginn Feature-Section).
+- **Akzeptanzkriterien:**
+  - [x] Komponente rendert keinen sichtbaren Bereich, wenn
+        `announcements` leer ist
+  - [x] Komponente rendert eine Karte pro aktiver Ankündigung, inkl. Bild
+        falls `imageUrl` gesetzt ist
+  - [x] `v-html`-Nutzung mit `eslint-disable-next-line vue/no-v-html`-
+        Kommentar (Projektkonvention)
+  - [x] `<AnnouncementBanner />` ist in `HomeView.vue` zwischen Hero- und
+        Feature-Section eingebunden
+  - [x] `npm run test` (Vitest) läuft grün für
+        `AnnouncementBanner.test.ts`
+  - [x] `npm run build` läuft ohne TypeScript-/Build-Fehler
+
+---
+
+## T11: Admin-Bereich `AnnouncementsView.vue`
+
+- **Agent:** dev-typescript
+- **Dateien:**
+  - `frontend/src/views/AnnouncementsView.vue` *(neu)*
+  - `frontend/src/views/AnnouncementsView.test.ts` *(neu)*
+  - `frontend/src/router/index.ts` *(ändern)*
+  - `frontend/src/layouts/DefaultLayout.vue` *(ändern)*
+- **Abhängigkeiten:** T09
+- **Beschreibung:**
+  Siehe `design.md` Abschnitt 8.1–8.3. Liste aller Ankündigungen
+  (`useAnnouncements().loadAll()`) inkl. abgelaufener mit Status-Badge
+  ("Aktiv"/"Abgelaufen" basierend auf `announcement.isActive`),
+  Create/Edit-Formular mit `<HtmlEditor v-model="form.body" />`
+  (bestehende Komponente) und `<FileUpload :multiple="false" />`
+  (bestehende Komponente), Zahlenfeld `displayDays` (1–365), Löschen mit
+  Bestätigung. Neue Route `announcements` (`requiresAdmin: true`) und
+  neuer Navigations-Eintrag ("Ankündigungen", `MegaphoneIcon`,
+  `roles: ['admin']`).
+- **Akzeptanzkriterien:**
+  - [x] Liste zeigt sowohl aktive als auch abgelaufene Ankündigungen mit
+        korrektem Status-Badge
+  - [x] Formular nutzt `HtmlEditor.vue` für `body` (kein neuer
+        Rich-Text-Editor)
+  - [x] Formular nutzt `FileUpload.vue` mit `:multiple="false"` für das
+        Bild
+  - [x] Route `/app/announcements` ist nur für `role === 'admin'`
+        erreichbar (Router-Guard `requiresAdmin`); Navigation zu dieser
+        Route für Nicht-Admins nicht sichtbar
+  - [x] Neuer Navigationspunkt "Ankündigungen" erscheint im Seitenmenü nur
+        für Admins
+  - [x] `npm run test` (Vitest) läuft grün für
+        `AnnouncementsView.test.ts`
+  - [x] `npm run build` läuft ohne TypeScript-/Build-Fehler

--- a/openspec/changes/archive/2026-07-17-add-announcement-banner/verification.md
+++ b/openspec/changes/archive/2026-07-17-add-announcement-banner/verification.md
@@ -1,0 +1,110 @@
+# Verification: add-announcement-banner
+
+**Gesamtstatus:** nacharbeit-am-design-nötig
+
+`openspec validate add-announcement-banner` → **"Change 'add-announcement-banner' is valid"** (strukturell ok, daher inhaltlicher Realitätsabgleich durchgeführt).
+
+---
+
+## Bestätigt
+
+### Backend — Sanitizing-Trait (proposal.md Z.45-51, design.md Abschnitt 3)
+- `backend/app/Http/Requests/Concerns/SanitizesHtmlContent.php` existiert, Trait mit `ALLOWED_HTML_TAGS` (`p, br, strong, em, h2, h3, ul, ol, li, blockquote, code, pre`) und Methode `sanitizeHtmlDescription()` → bestätigt, Datei vollständig gelesen.
+- Verwendung in `backend/app/Http/Requests/StoreCourseRequest.php:91` (Aufruf `$this->sanitizeHtmlDescription($snakeCase['description'])`, innerhalb des Blocks Z.89-92) → bestätigt (proposal.md zitiert "Z.89-92", tatsächlicher Aufruf ist Z.91, liegt aber exakt im zitierten Block). Ebenso in `UpdateCourseRequest.php:91`.
+- `StoreCourseRequest.php:38`: `'description' => ['nullable', 'string', 'max:5000']` → bestätigt, `max:5000` ist identisch zur in design.md Abschnitt 4.2 referenzierten Grenze für `body`.
+
+### Frontend — HtmlEditor / dompurify (proposal.md Z.39-40, 149; design.md Abschnitt 3)
+- `frontend/src/components/HtmlEditor.vue` existiert, `defineProps<{ modelValue: string }>` + `emit('update:modelValue', ...)` (Z.80-92) → bestätigt, Tiptap-/DOMPurify-basiert wie behauptet.
+- `frontend/package.json:21`: `"dompurify": "^3.3.1"` → bestätigt.
+- `frontend/package.json:18-20`: `@tiptap/pm`, `@tiptap/starter-kit`, `@tiptap/vue-3` → bestätigt.
+
+### CoursesView.vue-Anzeigemuster (proposal.md Z.150-152, design.md Abschnitt 3/7.1)
+- `frontend/src/views/courses/CoursesView.vue:319-320`: `const ALLOWED_TAGS = [...]` mit exakt derselben Tag-Liste wie das Backend-Trait, Kommentar `/** Allowed HTML tags consistent with the backend sanitization allowlist. */` → bestätigt (design.md zitiert Z.319-325, tatsächliche Kernzeilen sind 319-320/324, liegt im zitierten Bereich).
+
+### Multipart-`_method=PUT`-Override (proposal.md Z.154-156, design.md Abschnitt 5.2/6.1)
+- `frontend/src/api/settings.ts:35-58`: `async updateSettings(...)` mit `formData.set('_method', 'PUT')` (Z.51) und `apiClient.post(..., { headers: { 'Content-Type': 'multipart/form-data' } })` (Z.60-64) → bestätigt, Zeilenangabe exakt.
+- `openspec/changes/archive/2026-07-01-fix-settings-upload-put-multipart/` existiert als Verzeichnis mit `proposal.md`, `design.md`, `acceptance.md` etc. → bestätigt, Referenz auf archivierten Change ist korrekt.
+- `backend/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:143`: `$request->enableHttpMethodParameterOverride();` wird vom Framework automatisch aufgerufen (kein anwendungsseitiger Code nötig) → bestätigt, mechanistische Behauptung in design.md Abschnitt 5.2 trifft zu.
+
+### SettingPolicy / DogController-Upload-Werte (proposal.md Z.100-108, design.md Abschnitt 4.1/4.2)
+- `backend/app/Policies/SettingPolicy.php`: alle fünf Methoden (`viewAny`, `view`, `create`, `update`, `delete`) prüfen ausschließlich `$user->isAdmin()` → bestätigt, Muster ist 1:1 wie in design.md Abschnitt 4.1 vorgeschlagen.
+- `backend/app/Models/User.php:91-94`: `public function isAdmin(): bool { return $this->role === 'admin'; }` → bestätigt.
+- `backend/app/Http/Controllers/Api/DogController.php:185`: `'image' => ['required', 'image', 'mimes:jpg,jpeg,png,gif,webp', 'max:5120']` → bestätigt, exakte Übereinstimmung mit dem in design.md Abschnitt 4.2 zitierten Wert.
+- `DogController.php:192-193, 197`: Alt-Bild-Löschung vor `Storage::disk('public')`/`storeAs()`-Speicherung mit `Str::uuid()` im Dateinamen → bestätigt, Muster stimmt mit dem in design.md Abschnitt 5.1 nachgebauten Controller-Code überein.
+- `DogController.php:105-110` (`store()`): kein `$this->authorize()`-Aufruf, verlässt sich auf `StoreDogRequest::authorize()` → bestätigt, `DogController` nutzt `AuthorizesRequests`-Trait (Z.19, Z.34) wie behauptet.
+
+### DB-Portabilität / Migration (design.md Abschnitt 2.2, tasks.md T01)
+- `Schema::create()`, `string`, `text`, `unsignedSmallInteger`, `timestamp`, `timestamps`, `index` sind treiberneutrale Blueprint-Methoden; `unsignedSmallInteger` existiert in `backend/vendor/laravel/framework/src/Illuminate/Database/Schema/Blueprint.php:982` → bestätigt, keine Postgres-/MySQL-spezifischen Konstrukte in der Migration.
+
+### PHP-Kompatibilität (CLAUDE.md Abschnitt 4.1)
+- Vorgeschlagener Model-Code (`Announcement.php`, design.md Abschnitt 2.3) nutzt `protected function casts(): array` (Laravel-11-Konvention, kein PHP-8.3/8.4-Feature), keine Property Hooks, keine typed class constants, kein `#[\Override]`, keine `new MyClass()->method()`-Syntax → bestätigt, kein verbotenes Konstrukt gefunden.
+- `backend/composer.json:16`: `"laravel/framework": "^11.31"` → bestätigt, Laravel 11, `casts(): array`-Konvention korrekt angewendet.
+
+### `masterminds/html5` als transitive Abhängigkeit (design.md Abschnitt 3)
+- `backend/composer.lock:693`: `"masterminds/html5": "^2.0"` als `require`-Eintrag von `dompdf/dompdf` (nicht direkt vom Projekt) → bestätigt.
+- `backend/composer.json:15`: `"barryvdh/laravel-dompdf": "^3.1"` als direkte Projekt-Abhängigkeit, die `dompdf/dompdf` transitiv zieht → bestätigt, die Kette "masterminds/html5 kommt über barryvdh/laravel-dompdf" stimmt.
+
+### Fehlende QA-Scripts (proposal.md "Out of Scope", Z.131-140)
+- `backend/composer.json:48-63`: `"scripts"` enthält nur Laravel-Standard-Hooks (`post-autoload-dump`, `post-update-cmd`, `post-root-package-install`, `post-create-project-cmd`) — **kein** `test`, `lint`, `stan`, `qa`, `compat-check` → bestätigt.
+- `frontend/package.json:6-16`: `"scripts"` enthält `dev`, `build`, `build:deploy`, `preview`, `test`, `test:ui`, `test:coverage`, `e2e`, `e2e:ui` — **kein** `lint` → bestätigt.
+
+### Router / Layout / HomeView-Einfügepunkte (design.md Abschnitt 7.2, 8.2, 8.3)
+- `frontend/src/views/HomeView.vue:26`: schließendes `</section>` der Hero-Section; Z.28: Kommentar `<!-- Features Section -->`; Z.29: öffnendes `<section>` → bestätigt, exakte Zeilenangabe.
+- `HomeView.vue:205-206`: `import PricingModal ...` (Z.205), `import { usePricingItems } ...` (Z.206) → bestätigt.
+- `HomeView.vue:209, 217`: `const { groups, loading: pricingLoading, loadPublic } = usePricingItems()` (Z.209), `onMounted(() => loadPublic())` (Z.217) → bestätigt, design.md-Begründung zu `PricingModal` vs. `AnnouncementBanner` ist korrekt hergeleitet.
+- `frontend/src/router/index.ts:127-131`: `settings`-Routen-Eintrag; Z.133: `training-logs`-Eintrag beginnt → bestätigt.
+- `frontend/src/router/index.ts:181-185`: Router-Guard `if (to.meta.requiresAdmin && !authStore.isAdmin)` (konkret Z.182-185, Kommentar Z.181) → bestätigt.
+- `frontend/src/layouts/DefaultLayout.vue:110-126`: Heroicons-Import-Liste → bestätigt.
+- `DefaultLayout.vue:227-232`: "Einstellungen"-Navigationseintrag; Z.233-238: "Kontakt"-Eintrag → bestätigt.
+- `frontend/node_modules/@heroicons/vue/24/outline/MegaphoneIcon.js` existiert → bestätigt.
+
+### Routen-Einfügepunkte Backend (design.md Abschnitt 5.2, tasks.md T07)
+- `backend/routes/api.php:6-7`: `AnamnesisTemplateController`-Import (Z.6), `AuthController`-Import (Z.7); alphabetisch liegt `AnnouncementController` dazwischen (`Anam...` < `Announ...` < `Auth...`) → bestätigt.
+- `backend/routes/api.php:54-57`: "Public pricing route"-Block; Z.59: "Public course detail route"-Kommentar → bestätigt, exakte Zeilenangabe.
+- `backend/routes/api.php:192-196`: "Settings Management"-Block; Z.197: schließendes `});` der äußeren `auth:sanctum`-Gruppe → bestätigt (design.md nennt "Z.192-195" für den Block und "Z.197" für die Klammer — der Block selbst endet tatsächlich bei Z.196, was in etwa im zitierten Bereich liegt; die Klammer-Zeile 197 stimmt exakt).
+- `backend/routes/api.php:80, 188, 193`: bestehende `Route::middleware('can:admin')->group(...)`-Verwendung → bestätigt, Middleware-Name `can:admin` existiert bereits im Projekt.
+
+### Frontend-Vorbilder für T09/T11 (design.md Abschnitt 6.1, 6.2, 8.1)
+- `frontend/src/api/pricingItems.ts` existiert mit vergleichbarer Struktur (`getPublic`, `getAll`, `create`, `update`) → bestätigt.
+- `frontend/src/composables/usePricingItems.ts` existiert → bestätigt.
+- `frontend/src/views/SettingsView.vue`, `frontend/src/components/FileUpload.vue`, `frontend/src/components/PricingItemForm.vue`, `frontend/src/components/DogFormModal.vue` existieren alle → bestätigt.
+- `frontend/src/components/FileUpload.vue:170,177`: Prop `multiple?: boolean`, Default `false` → bestätigt, `:multiple="false"` ist eine gültige, bereits unterstützte Prop-Belegung.
+
+## Widerlegt
+
+### CustomerCredit.php als Vorbild für den `saving`-Hook-Berechnungsansatz (design.md Abschnitt 2.1, Z.37-52)
+Design.md behauptet: *"Das Projekt hat für exakt dieses Problem bereits ein etabliertes Muster: `backend/app/Models/CustomerCredit.php:118-129` — ein Ablaufdatum wird **einmalig in PHP berechnet** und in einer eigenen Spalte gespeichert (`expiration_date`)"*.
+
+Tatsächlich (vollständig gelesen: `backend/app/Models/CustomerCredit.php`, `backend/app/Http/Requests/StoreCustomerCreditRequest.php`, `backend/database/factories/CustomerCreditFactory.php`):
+- `CustomerCredit.php` enthält **keinen** `booted()`/`saving`-Hook und **keine** Methode, die `expiration_date` aus `purchase_date` + einer Dauer berechnet. Die Zeilen 118-129 des tatsächlichen Files sind die Dokumentation und der Body von `scopeActive()` (reine Filterung, keine Berechnung).
+- `StoreCustomerCreditRequest.php:32,70`: `expirationDate` ist ein **vom Admin direkt im Request mitgegebenes, optionales Feld** (`'expirationDate' => ['nullable', 'date', 'after:purchaseDate']`), das unverändert in `expiration_date` übernommen wird (`$validated['expirationDate'] ?? null`) — es wird **nicht** aus `purchase_date` + einer Tages-/Laufzeitangabe berechnet.
+- `CustomerCreditFactory.php:27,40`: auch dort wird `expiration_date` mit hartkodierten `now()->addDays(...)`-Werten direkt gesetzt, nicht über ein Model-Event berechnet.
+
+**Fazit:** Der von design.md als Präzedenzfall zitierte Mechanismus für "automatische Berechnung eines Ablaufdatums beim Speichern via Model-Hook" existiert in `CustomerCredit` **nicht**. Bestätigt ist lediglich der allgemeinere, unstrittige Teil des Musters: ein Ablaufzeitpunkt wird in einer eigenen Spalte persistiert und über eine treiberneutrale Eloquent-`where`-Bedingung (`scopeActive()`/`scopeExpired()`) gefiltert, statt Datums-Arithmetik in raw SQL auszudrücken. Der `saving`-Hook-Ansatz für `Announcement` (design.md Abschnitt 2.3) ist somit ein **neuer** Mechanismus im Projekt, kein wiederverwendetes, bereits produktiv erprobtes Muster, auch wenn die DB-Portabilitäts-Begründung (kein raw SQL) für sich genommen korrekt bleibt.
+
+### `announcementsApi.update()` übernimmt NICHT "exakt" das Multipart-Header-Muster aus `settings.ts` (design.md Abschnitt 6.1, Behauptung Z.556-559)
+Design.md behauptet, der Code in Abschnitt 6.1 übernehme "exakt das `_method=PUT`-Override-Muster aus `frontend/src/api/settings.ts:35-58`". Tatsächlich fehlt im in design.md Abschnitt 6.1 gezeigten Code (`announcementsApi.create`/`update`) der in `settings.ts:60-64` **und** `frontend/src/api/trainingAttachments.ts:52-55` (zweites, unabhängiges Beispiel im Projekt) konsistent vorhandene explizite Header-Override `headers: { 'Content-Type': 'multipart/form-data' }`.
+
+Das ist folgenreich, nicht nur kosmetisch: `frontend/src/api/client.ts:34-38` setzt `apiClient` mit dem **Default-Header** `'Content-Type': 'application/json'` für **alle** Requests auf. In `frontend/node_modules/axios/lib/defaults/index.js:49-56` (`transformRequest`) prüft Axios `isFormData(data)` **und** `hasJSONContentType` (aus dem bereits gesetzten `Content-Type`-Header): Ist Letzteres `true`, wird die `FormData` **nicht** als multipart gesendet, sondern über `formDataToJSON(data)` in einen JSON-String umgewandelt (`return hasJSONContentType ? JSON.stringify(formDataToJSON(data)) : data;`). Ohne den expliziten Header-Override würde ein `apiClient.post(url, buildFormData(data))`-Aufruf mit dem aktuellen `apiClient`-Default-Header also **kein** echtes `multipart/form-data` senden — der Bild-Upload und das `_method=PUT`-Override-Feld würden fehlschlagen bzw. anders serialisiert werden als beabsichtigt.
+
+**Fazit:** Die Behauptung "exakt dasselbe Muster" trifft auf den in design.md Abschnitt 6.1 abgedruckten Code **nicht** zu — ihm fehlt ein Element, das in **beiden** bestehenden FormData-Upload-Stellen im Projekt (`settings.ts`, `trainingAttachments.ts`) konsistent vorhanden ist und das laut verifiziertem Axios-Verhalten für die korrekte Funktion notwendig ist.
+
+## Nicht auffindbar
+
+- Keine Behauptung in proposal.md/design.md/tasks.md konnte nicht auffindbar bewertet werden — alle konkreten Codebasis-Behauptungen waren entweder bestätigbar oder widerlegbar.
+
+## Neue Elemente (Plausibilität)
+
+- `backend/database/migrations/2026_07_17_100000_create_announcements_table.php` (T01) → Migrationsverzeichnis `backend/database/migrations/` existiert, Namenskonvention (`YYYY_MM_DD_HHMMSS_create_x_table.php`) konsistent mit vorhandenen Migrationen; kein Namenskonflikt gefunden.
+- `backend/app/Models/Announcement.php`, `backend/database/factories/AnnouncementFactory.php` (T02) → `backend/app/Models/` und `backend/database/factories/` existieren, kein `Announcement`/`AnnouncementFactory` bereits vorhanden.
+- `backend/app/Policies/AnnouncementPolicy.php` (T03) → `backend/app/Policies/` existiert (`SettingPolicy.php`, `CustomerCreditPolicy.php` als Nachbarn bestätigt gelesen), kein Konflikt.
+- `backend/app/Http/Requests/StoreAnnouncementRequest.php` / `UpdateAnnouncementRequest.php` (T04), `backend/app/Http/Resources/AnnouncementResource.php` (T05), `backend/app/Http/Controllers/Api/AnnouncementController.php` (T06) → jeweilige Zielverzeichnisse existieren mit gleichartig benannten Geschwister-Klassen (`StoreCourseRequest.php`, `DogController.php` etc.), kein Namenskonflikt.
+- `backend/tests/Feature/Api/AnnouncementApiTest.php` (T08) → `backend/tests/Feature/Api/` existiert (Konvention laut `TESTING.md` bestätigt), kein Konflikt.
+- `frontend/src/api/announcements.ts`, `frontend/src/composables/useAnnouncements.ts` (T09) → Zielverzeichnisse existieren mit vergleichbaren Dateien (`pricingItems.ts`, `usePricingItems.ts`), kein Konflikt.
+- `frontend/src/components/AnnouncementBanner.vue` (T10) → `frontend/src/components/` existiert, kein Namenskonflikt.
+- `frontend/src/views/AnnouncementsView.vue`, Route `/app/announcements` (T11) → `frontend/src/views/` existiert, Pfad `announcements` ist im Router noch nicht vergeben (geprüft über `router/index.ts`-Auszug Z.120-140), kein Konflikt mit bestehenden Routen (`invoices`, `settings`, `training-logs`).
+- `announcement-images/`-Verzeichnis auf der `public`-Disk → `backend/storage/app/public/` enthält bereits `settings/` und `dog-images/` als Geschwister-Verzeichnisse, kein Namenskonflikt mit `announcement-images/`.
+
+## Empfehlung
+
+Die Spec ist strukturell solide und die überwiegende Mehrheit der konkreten Codebasis-Behauptungen (Backend-Routen-Einfügepunkte, Frontend-Einfügepunkte, Policy-/Validierungs-Muster, DB-Portabilität, PHP-8.2-Konformität, fehlende QA-Scripts) ist exakt mit Datei:Zeile belegbar. Zwei Punkte sind vor Freigabe zu korrigieren: (1) der als Präzedenzfall zitierte `CustomerCredit`-"berechnet-beim-Speichern"-Mechanismus existiert so nicht im Code — der Architekt sollte den `saving`-Hook-Ansatz für `Announcement` als **neuen** Mechanismus kennzeichnen statt als Wiederverwendung eines bestehenden Musters; (2) der Code-Vorschlag für `announcementsApi.create`/`update` in design.md Abschnitt 6.1 fehlt der in beiden bestehenden FormData-Upload-Stellen des Projekts (`settings.ts`, `trainingAttachments.ts`) vorhandene explizite `Content-Type: multipart/form-data`-Header-Override — ohne ihn würde der Multipart-Body laut verifiziertem Axios-Verhalten fälschlich zu JSON serialisiert. Architekt sollte design.md Abschnitt 6.1 entsprechend korrigieren, bevor T09 implementiert wird.

--- a/openspec/specs/announcement-management/spec.md
+++ b/openspec/specs/announcement-management/spec.md
@@ -1,0 +1,161 @@
+# Announcement Management
+
+**Capability:** announcement-management
+
+## Purpose
+
+Allows admins to publish time-limited announcements (rich-text body, optional
+image, configurable display duration) that appear on the public landing page
+between the hero section and the "Unsere Leistungen" feature section, and to
+manage them (including viewing expired ones) without requiring a scheduler or
+cron job.
+
+## Requirements
+
+### Requirement: Admins can create announcements with rich text, an optional image, and a display duration
+
+The system SHALL allow an authenticated user with the `admin` role to create
+an announcement consisting of a `title`, a rich-text `body` (HTML,
+server-side sanitized), an optional single image, and a `displayDays` value
+(integer, 1–365) that determines how long the announcement remains active.
+
+Non-admin users (including unauthenticated requests) SHALL NOT be able to
+create, update, or delete announcements.
+
+#### Scenario: Admin creates an announcement with all fields
+- **WHEN** an admin submits `POST /api/v1/admin/announcements` with
+  `title`, `body`, `displayDays`, and an image file
+- **THEN** the system SHALL persist the announcement
+- **AND** the response SHALL include `imageUrl` pointing to the stored
+  image on the `public` disk
+
+#### Scenario: Admin creates an announcement without an image
+- **WHEN** an admin submits `POST /api/v1/admin/announcements` with
+  `title`, `body`, and `displayDays`, but no image
+- **THEN** the system SHALL create the announcement successfully
+- **AND** `imageUrl` SHALL be `null` in the response
+
+#### Scenario: Non-admin is rejected
+- **WHEN** a non-admin (or unauthenticated) request attempts
+  `POST /api/v1/admin/announcements`, `PUT
+  /api/v1/admin/announcements/{id}`, or
+  `DELETE /api/v1/admin/announcements/{id}`
+- **THEN** the system SHALL respond with HTTP 403 (or 401 if unauthenticated)
+- **AND** SHALL NOT persist any change
+
+#### Scenario: Invalid display duration is rejected
+- **WHEN** a request to create or update an announcement includes a
+  `displayDays` value outside the range 1–365
+- **THEN** the system SHALL respond with HTTP 422
+- **AND** SHALL NOT persist the invalid value
+
+---
+
+### Requirement: Announcement body HTML is sanitized server-side before storage
+
+The system SHALL strip any HTML tags and attributes not on the project's
+established rich-text allowlist (`p, br, strong, em, h2, h3, ul, ol, li,
+blockquote, code, pre`, no attributes) from the `body` field before
+persisting an announcement, regardless of what the client sends.
+
+#### Scenario: Disallowed tags and event-handler attributes are removed
+- **WHEN** an admin submits a `body` value containing `<script>` tags or an
+  `onclick` attribute on an otherwise-allowed tag (e.g.
+  `<strong onclick="...">`)
+- **THEN** the system SHALL store the value with the disallowed tag
+  removed and all attributes stripped from the remaining allowed tags
+- **AND** SHALL NOT execute or persist the injected script/attribute
+
+#### Scenario: Allowed formatting is preserved
+- **WHEN** an admin submits a `body` value using only allowed tags (e.g.
+  `<p>`, `<strong>`, `<ul><li>`)
+- **THEN** the system SHALL persist the formatting unchanged (aside from
+  attribute stripping)
+
+---
+
+### Requirement: Multiple announcements can be active at the same time
+
+The system SHALL support more than one announcement being active
+simultaneously. There SHALL be no mechanism that deactivates or hides one
+active announcement when another is created or becomes active.
+
+#### Scenario: Two announcements are active at once
+- **WHEN** two announcements exist whose display windows both currently
+  cover `now()`
+- **THEN** the public endpoint SHALL return both in its response list
+
+---
+
+### Requirement: Announcement expiry is computed from the display duration without a scheduler
+
+The system SHALL determine whether an announcement is currently active by
+comparing a persisted `expiresAt` timestamp (computed from the
+announcement's original creation time plus `displayDays`) against the
+current time at read time. No scheduled task, cron job, or queue worker
+SHALL be required to deactivate an expired announcement.
+
+#### Scenario: Announcement becomes inactive after its display duration elapses
+- **WHEN** an announcement was created with `displayDays = 3` and more
+  than 3 days have since passed
+- **THEN** the public endpoint (`GET /api/v1/announcements`) SHALL NOT
+  include this announcement in its response
+- **AND** no scheduled job needs to run for this to take effect
+
+#### Scenario: Editing an announcement's text does not silently extend its display window
+- **WHEN** an admin updates only the `title` or `body` of an existing
+  announcement, without changing `displayDays`
+- **THEN** the announcement's `expiresAt` SHALL remain based on its
+  original creation time, not the edit time
+
+#### Scenario: Changing displayDays recalculates the expiry from the original creation time
+- **WHEN** an admin updates `displayDays` on an existing, not-yet-expired
+  announcement
+- **THEN** the system SHALL recompute `expiresAt` as the announcement's
+  original `createdAt` plus the new `displayDays` value (not from the
+  edit time)
+
+---
+
+### Requirement: Public landing page displays only currently active announcements
+
+The system SHALL expose a public, unauthenticated endpoint
+(`GET /api/v1/announcements`) that returns only announcements that are
+currently active. The public landing page (`HomeView.vue`) SHALL render an
+announcement section between the hero section and the "Unsere
+Leistungen" feature section only when at least one active announcement
+exists; otherwise the section SHALL NOT be rendered.
+
+#### Scenario: No active announcements exist
+- **WHEN** no announcement is currently active
+- **THEN** `GET /api/v1/announcements` SHALL return an empty list
+- **AND** the landing page SHALL NOT render the announcement section
+
+#### Scenario: At least one active announcement exists
+- **WHEN** at least one announcement is currently active
+- **THEN** the landing page SHALL render the announcement section between
+  the hero section and the "Unsere Leistungen" section
+- **AND** each active announcement SHALL be displayed with its
+  sanitized rich-text body and image (if present)
+
+---
+
+### Requirement: Admin area lists all announcements including expired ones, with a status indicator
+
+The system SHALL provide an admin-only view that lists **all**
+announcements — both currently active and expired — without automatically
+deleting expired ones. Each entry SHALL be labeled with its current status
+(active or expired).
+
+#### Scenario: Admin views the announcement list
+- **WHEN** an admin navigates to the announcement management area
+- **THEN** the system SHALL display all announcements, each with a status
+  label of "active" or "expired" matching whether `expiresAt` is in the
+  future or the past
+- **AND** expired announcements SHALL remain visible and editable/deletable,
+  not hidden or auto-removed
+
+#### Scenario: Admin deletes an announcement
+- **WHEN** an admin deletes an announcement that has an associated image
+- **THEN** the system SHALL remove the announcement record
+- **AND** SHALL delete the associated image file from storage

--- a/openspec/triage/20260717103000-announcement-banner.md
+++ b/openspec/triage/20260717103000-announcement-banner.md
@@ -1,0 +1,139 @@
+# Triage: Ankündigungs-Bereich (Landingpage + Admin-Verwaltung)
+
+**Pfad:** standard
+**Geschätzter Umfang:** ca. 10-14 neue/geänderte Dateien, PHP (Backend) + TypeScript/Vue (Frontend)
+**Risiko:** mittel — neues Datenmodell samt Migration, File-Upload auf Shared Hosting, Auth/Rollen-Check für Admin-Formular, aber keine bestehenden öffentlichen Schnittstellen werden gebrochen.
+**Klarheit:** mehrdeutig — Kernidee ist klar, aber mehrere Detailfragen zu Verhalten, Darstellung und Mehrfach-Ankündigungen sind offen (siehe unten).
+
+## Anforderung (Zusammenfassung)
+
+Auf der öffentlichen Landingpage (`frontend/src/views/HomeView.vue`, Hero-Section
+"Willkommen bei der Hundeschule HomoCanis" in Zeile 4-26, gefolgt von der
+Feature-Section "Unsere Leistungen" ab Zeile 29) soll zwischen diesen beiden
+Sections ein optionaler Ankündigungsbereich erscheinen, der nur sichtbar ist,
+wenn eine aktive Ankündigung existiert. Als Admin soll es ein Formular geben,
+um Ankündigungen zu pflegen: Text, Bild-Upload und eine Anzeigedauer in Tagen,
+nach deren Ablauf die Ankündigung automatisch nicht mehr angezeigt wird.
+
+## Rückfragen an den User (nur wenn Klarheit = mehrdeutig)
+
+- Kann es **mehrere gleichzeitig aktive** Ankündigungen geben (Liste/Karussell)
+  oder immer nur genau eine aktuell sichtbare?
+- Wie wird die **Anzeigedauer** technisch verstanden: "X Tage ab Veröffentlichung"
+  oder "X Tage ab dem Zeitpunkt, an dem der Admin sie einträgt"? Braucht es
+  zusätzlich einen manuellen "jetzt veröffentlichen" / "sofort deaktivieren"-Schalter,
+  oder reicht reines Ablaufdatum aus Anzeigedauer?
+- Soll der Ablauf **serverseitig** (z. B. per Scheduler/Cron, siehe
+  Shared-Hosting-Einschränkung in `CLAUDE.md` Abschnitt 4.3 — kein Daemon,
+  nur `schedule:run` per Hoster-Cron) oder rein **anzeigeseitig** berechnet
+  werden (Ankündigung bleibt in der DB, wird aber nur ausgeblendet, wenn
+  `created_at + Anzeigedauer < now()`)? Das beeinflusst, ob überhaupt ein
+  Scheduler-Task nötig ist.
+- Ist **ein Bild** pro Ankündigung ausreichend, oder werden mehrere Bilder
+  bzw. eine Galerie erwartet?
+- Soll der Ankündigungstext **Rich-Text/HTML** unterstützen (z. B. Fett,
+  Links) oder reicht Plain-Text mit Zeilenumbrüchen? Das beeinflusst
+  Sanitizing-Aufwand (XSS) im Backend.
+- Braucht es eine **Historie** früherer Ankündigungen (Liste im Admin-Bereich
+  mit "aktiv/abgelaufen"-Status) oder wird die aktuelle Ankündigung beim
+  Bearbeiten einfach überschrieben?
+
+## Ungeprüfte Referenzen
+
+- Keine — alle im Auftrag genannten Bezugspunkte ("Willkommen bei der
+  Hundeschule ...", "Unsere Leistungen") wurden in
+  `frontend/src/views/HomeView.vue:11` bzw. `:33` verifiziert.
+
+## Codebasis-Befunde (mit Beleg)
+
+- **Landingpage:** `frontend/src/views/HomeView.vue:1-40` — Hero-Section
+  endet Zeile 26, Feature-Section "Unsere Leistungen" beginnt Zeile 29. Der
+  neue Bereich müsste dazwischen eingefügt werden (conditional `v-if`).
+- **Vorbild für admin-pflegbare Inhalte:** `backend/app/Models/Setting.php`
+  (Key-Value-Store mit `type`/`group`, Cache-Invalidierung) und
+  `backend/app/Http/Controllers/Api/SettingsController.php:1-75` (Validierung,
+  `$this->authorize(...)`, Datei-Upload für `email_logo` via
+  `mimes:png,jpg,jpeg,svg|max:2048`). Eine Ankündigung ist aber eher ein
+  eigenständiges Model mit Lebenszyklus (aktiv/abgelaufen) als ein einzelner
+  Setting-Key — spricht für ein eigenes `Announcement`-Model + Migration statt
+  Wiederverwendung von `Setting`.
+- **Existierendes Upload-Pattern (Bild):** `backend/database/migrations/2026_05_04_100000_add_profile_image_to_dogs_table.php`
+  (String-Spalte `profile_image`, nullable) und
+  `backend/app/Http/Controllers/Api/DogController.php:192-193`
+  (`Storage::disk('public')->exists(...)` / `delete(...)`) — etabliertes
+  Muster: Pfad in DB, Datei auf `public`-Disk via `storage:link`
+  (siehe `CLAUDE.md` Abschnitt 4.3, Shared-Hosting-Symlink-Hinweis).
+- **Frontend-Upload-Komponente:** `frontend/src/components/FileUpload.vue`
+  (Dropzone, Multiple-Support, Preview) — wiederverwendbar für den
+  Bild-Upload im Admin-Formular, ggf. mit `multiple=false`.
+- **Rollen-/Admin-Check Frontend:** `frontend/src/router/index.ts:181-196`
+  — Pattern `requiresRole` / `requiresAdmin`, admin hat immer Zugriff. Neue
+  Admin-Route für das Ankündigungsformular kann dieses Pattern übernehmen.
+- **Kein bestehendes Announcement/Banner-Model gefunden:**
+  `backend/app/Models/` enthält kein `Announcement`, `Banner` o. Ä. (siehe
+  vollständige Liste oben) — es handelt sich um eine komplett neue Capability.
+- **Kein Admin-Views-Verzeichnis, sondern flache Views mit Rollen-Guard:**
+  `frontend/src/views/SettingsView.vue` ist das nächstliegende Vorbild für
+  eine "Admin bearbeitet globale Inhalte"-Seite.
+
+## Betroffene Bereiche (Schätzung)
+
+- **Backend (`dev-php`):**
+  - Migration `create_announcements_table` (Felder mind.: `text`, `image_path`
+    nullable, `display_days`/`expires_at`, `is_active` oder berechnet,
+    Timestamps) — MySQL/Postgres-kompatibel gemäß Abschnitt 4.2 der `CLAUDE.md`
+  - Model `Announcement` (fillable, casts, ggf. Scope `active()`)
+  - Policy für Admin-only Schreibzugriff
+  - Controller `Api/AnnouncementController` (index/store/update/destroy,
+    Datei-Upload wie in `SettingsController`)
+  - API-Resource für die öffentliche Ausgabe (kein Admin-only-Feld leaken)
+  - Route-Eintrag (public GET aktive Ankündigung, admin-only POST/PUT/DELETE)
+- **Frontend (`dev-typescript`):**
+  - Öffentliche Anzeige-Komponente (z. B. `AnnouncementBanner.vue`) in
+    `HomeView.vue` zwischen Zeile 26 und 29 eingebunden, bedingtes Rendering
+  - Admin-Formular-Komponente/View (Text, Bild-Upload via `FileUpload.vue`,
+    Zahleneingabe Anzeigedauer), neue Route mit `requiresRole: 'admin'`
+  - API-Client-Funktionen in `frontend/src/api/`
+  - Vitest-Tests für beide Komponenten
+
+Damit sind mindestens zwei Sprach-Stacks, ein neues Datenmodell mit Migration
+und File-Upload sowie ein neuer Auth-geschützter Bereich betroffen — das
+übersteigt "klein" (1-3 Dateien). Da die Kernanforderung aber klar umrissen
+ist und keine Architektur-Zerlegung in mehrere Teil-Changes nötig erscheint
+(kein Eingriff in bestehende Module, kein Multi-Sprachen-Kernkonflikt), wird
+**"standard"** statt "groß" empfohlen — vorausgesetzt, die Rückfragen oben
+werden vor der Architektur-Phase geklärt, da sie die Migration-Struktur
+(z. B. `expires_at` vs. reine `display_days`-Berechnung) direkt beeinflussen.
+
+## Entscheidungen des Users (2026-07-17)
+
+- **Ablauf-Berechnung:** anzeigeseitig (`created_at`/`published_at` +
+  `display_days` < `now()`), **kein** Scheduler/Cron-Task nötig.
+- **Mehrfach-Ankündigungen:** Es können **mehrere gleichzeitig aktive**
+  Ankündigungen existieren (Liste, kein Überschreiben einer einzelnen
+  Ankündigung). Frontend zeigt alle aktiven Ankündigungen an (Liste oder
+  Karussell — Detail-Layout entscheidet der Architekt/Designer).
+- **Bilder:** genau **ein Bild** pro Ankündigung (kein Galerie-Feature).
+- **Text-Format:** **Rich-Text (HTML)**. Erfordert einen Rich-Text-Editor
+  im Admin-Formular sowie serverseitiges HTML-Sanitizing beim Speichern
+  (XSS-Schutz — kein rohes HTML ungefiltert in DB/Ausgabe durchreichen).
+
+Damit entfällt die Rückfrage zu "Historie" nicht automatisch — das Modell
+mit mehreren gleichzeitig aktiven Ankündigungen impliziert ohnehin eine
+Liste im Admin-Bereich (aktive + abgelaufene Einträge sichtbar), der
+Architekt sollte das im `design.md` festlegen (z. B. abgelaufene Einträge
+weiterhin auflisten mit Status-Badge, statt sie zu löschen).
+
+## Empfohlene nächste Aktion
+
+Rückfragen oben zuerst mit dem User klären (insb. Ablauf-Berechnung
+serverseitig vs. anzeigeseitig, da das die Migration und ob ein
+Scheduler-Task nötig ist, direkt bestimmt). Danach:
+
+`@architect Erstelle den openspec-Change basierend auf
+openspec/triage/20260717103000-announcement-banner.md` — Modus A, Pfad
+"standard", vollständiger Workflow inkl. Skeptiker und User-Spec-Gate.
+Der Architekt sollte in `tasks.md` mindestens zwei Tasks anlegen: eine für
+`dev-php` (Migration/Model/Controller/Route/Policy) und eine für
+`dev-typescript` (öffentliche Anzeige-Komponente + Admin-Formular), mit
+klarem Übergabepunkt über den API-Response-Shape der Announcement-Resource.

--- a/openspec/triage/20260717173845-fix-dompurify-vitest-isolation-ci-flake.md
+++ b/openspec/triage/20260717173845-fix-dompurify-vitest-isolation-ci-flake.md
@@ -1,0 +1,98 @@
+# Triage: fix-dompurify-vitest-isolation-ci-flake
+
+**Pfad:** klein
+**Geschätzter Umfang:** 1–4 Dateien (`frontend/vitest.config.ts` und/oder `frontend/src/components/AnnouncementBanner.vue`, `frontend/src/views/courses/CoursesView.vue` + je zugehörige `*.test.ts`), reines TypeScript/Vue-Frontend.
+**Risiko:** niedrig — reines Test-/Tooling-Problem ohne bestätigten Produktivcode-Fehler; leicht erhöht auf mittel, falls der gewählte Fix `DOMPurify`-Instanziierung in Komponenten ändert (Berührt zwei Komponenten mit identischem Sanitizing-Muster, aber kein Schnittstellenbruch, keine Migration, kein Auth-Bezug).
+**Klarheit:** mehrdeutig — Root Cause ist gut gestützt, aber die konkrete Fix-Strategie (Vitest-Konfiguration vs. explizite DOMPurify-Instanziierung pro Komponente) ist noch offen und hat unterschiedliche Blast-Radien.
+
+## Anforderung (Zusammenfassung)
+
+In PR #70 (`feature/add-announcement-banner`) schlagen im GitHub-Actions-CI-Lauf
+2 von 191 Vitest-Tests in `frontend/src/components/AnnouncementBanner.test.ts`
+fehl (DOMPurify entfernt `<script>` bzw. `<img onerror>` nicht), obwohl dieselben
+Tests lokal (mehrfach, von zwei Agenten) durchgehend grün liefen. Der Bug-Report
+verlangt: (1) Root-Cause-Verifikation, (2) Bewertung möglicher Fixes inkl.
+Seiteneffekt auf `CoursesView.vue`/`CoursesView.test.ts`, (3) Workflow-Einordnung.
+
+## Read-only Verifikation (im Rahmen der Triage durchgeführt)
+
+- `frontend/src/components/AnnouncementBanner.vue:31,43-46` und
+  `frontend/src/views/courses/CoursesView.vue:319-320` nutzen beide den
+  **Default-Export** von `dompurify` (`import DOMPurify from 'dompurify'`)
+  und rufen `DOMPurify.sanitize(...)` auf — kein `createDOMPurify(window)`
+  pro Aufruf.
+- `node_modules/dompurify/dist/purify.cjs.js:1535`: `var purify = createDOMPurify();`
+  — das Default-Export-Singleton wird **einmalig beim ersten Modul-Require**
+  gebildet, gebunden an das zu diesem Zeitpunkt via `getGlobal()`
+  (`purify.cjs.js:342-344`, `typeof window === 'undefined' ? null : window`)
+  ermittelte `window`-Objekt. Das stützt die Kern-Hypothese des Bug-Reports:
+  Wird das Modul in einem Vitest-Worker-Prozess nur einmal geladen, aber
+  `happy-dom` erzeugt pro Testdatei ein neues `window`, bleibt der
+  Default-Export an das `window` der zuerst geladenen Testdatei gebunden.
+- `frontend/vitest.config.ts:8`: `environment: 'happy-dom'`, kein
+  explizites `isolate`/`pool` gesetzt (Vitest-Default). `package.json:40`
+  pinnt `vitest: ^4.0.16`, installiert ist `4.1.6`.
+- `.github/workflows/ci.yml:141-143`: CI führt `npm run test` (→ `vitest`,
+  ohne `run`-Subcommand) auf `ubuntu-latest`/Node 20 aus — abweichend von
+  lokalen Entwickler-Läufen. CPU-Kernzahl/Worker-Verteilung des
+  GitHub-Actions-Runners unterscheidet sich vermutlich von den lokalen
+  macOS-Umgebungen, was beeinflusst, ob mehrere Testdateien denselben
+  Worker (und damit denselben `dompurify`-Modul-Singleton) teilen.
+- `task-T10.notes.md` (archiviert unter
+  `openspec/changes/archive/2026-07-17-add-announcement-banner/task-T10.notes.md`)
+  dokumentiert bereits eine verwandte, kleinere happy-dom/DOMPurify-Eigenheit
+  bei der exakten Sequenz `<script>…</script><img>` — ein Indiz, dass das
+  Environment-Binding von DOMPurify unter `happy-dom` bereits einmal auffällig
+  war, aber damals als isolierter Einzelfall eingeordnet wurde.
+
+**Nicht abschließend verifiziert** (bewusst nicht Teil der Triage-Rolle,
+gehört in `verification.md`/Architekt-Design bzw. in die Entwickler-Notes):
+kein gezielter Mehrdatei-Vitest-Lauf zur direkten Reproduktion des
+Cross-File-Bleeds durchgeführt; Vitest-4-Default für `pool`/`isolate` und
+dessen genaues Verhalten bezüglich CJS-`require`-Cache-Teilung zwischen
+Testdateien im selben Worker wurde nicht im Quellcode von `vitest`
+nachvollzogen (nur `.d.ts`-Suche ohne Treffer). Das ist die Aufgabe des
+nächsten Agenten, nicht der Triage.
+
+**Ungeprüfte Referenz:** `frontend/src/components/AnnouncementBanner.integration.test.ts`
+existiert (per `find` bestätigt), wurde vom Bug-Report nicht erwähnt und
+in dieser Triage nicht inhaltlich geprüft — falls relevant, muss der
+Architekt/Entwickler das im Design berücksichtigen.
+
+## Rückfragen an den User (nur wenn Klarheit = mehrdeutig)
+
+- Bevorzugst du den **breiteren, projektweiten Fix** (Vitest-Konfiguration
+  auf echte Datei-Isolation umstellen, z. B. `pool: 'forks'` mit
+  `isolate: true` explizit oder `poolOptions.forks.singleFork: false`),
+  der potenziell alle Testdateien mit modul-globalem State betrifft und
+  damit auch `CoursesView.test.ts` proaktiv absichert — auch wenn dort
+  aktuell kein sichtbarer Fehler auftritt?
+- Oder bevorzugst du den **lokal begrenzten Fix** (explizite
+  `createDOMPurify(window)`-Instanziierung in `AnnouncementBanner.vue`
+  und, aus Konsistenzgründen, auch in `CoursesView.vue`), der
+  Produktivcode in zwei Komponenten ändert, aber unabhängig von
+  Vitest-internem Verhalten ist?
+- Soll `CoursesView.vue`/`CoursesView.test.ts` in jedem Fall mit
+  angefasst werden (Konsistenz-Argument), auch wenn dort aktuell keine
+  CI-Fehlschläge beobachtet wurden?
+
+## Empfohlene nächste Aktion
+
+`@architect` mit dem Auftrag, basierend auf dieser Triage-Datei einen
+`klein`-Change zu erstellen (`change-id` z. B.
+`fix-dompurify-vitest-isolation`). Der Architekt soll:
+
+1. Im `design.md` explizit zwischen den zwei Fix-Kandidaten (Vitest-Config
+   vs. `createDOMPurify(window)` in Komponenten) entscheiden bzw. beide
+   gegeneinander abwägen (Blast-Radius, Wartbarkeit, CI-Laufzeit-Impact
+   bei erzwungener Prozess-Isolation).
+2. Tasks für `frontend/vitest.config.ts` und/oder
+   `frontend/src/components/AnnouncementBanner.vue` und
+   `frontend/src/views/courses/CoursesView.vue` (inkl. je zugehöriger
+   `*.test.ts`) anlegen — alle Tasks mit `agent: dev-typescript`, da rein
+   TypeScript/Vue-Frontend betroffen ist.
+3. Im Design festhalten, dass die Pre-Flight-Checks aus `CLAUDE.md`
+   Abschnitt 7.1 (`npm run test`, `npm run build`) sowohl lokal als auch
+   idealerweise mit einem CI-nahen Worker-Setup laufen sollen, um die
+   Behebung tatsächlich gegen das beobachtete CI-Verhalten zu verifizieren
+   (nicht nur gegen den bereits mehrfach falsch-grünen lokalen Lauf).


### PR DESCRIPTION
## Summary
- Neues Datenmodell `Announcement` (Migration, Model, Policy, FormRequests, Resource, Controller, Routen) für zeitlich befristete Ankündigungen mit Rich-Text-Body (serverseitig sanitized), optionalem Bild und Anzeigedauer in Tagen (1–365).
- Ablauf wird **anzeigeseitig** über einen vorausberechneten `expires_at`-Wert bestimmt — kein Scheduler/Cron nötig (Shared-Hosting-Einschränkung, siehe CLAUDE.md Abschnitt 4.3).
- Öffentliche Komponente `AnnouncementBanner.vue`, eingebunden in `HomeView.vue` zwischen Hero- und "Unsere Leistungen"-Section; zeigt alle aktuell aktiven Ankündigungen (mehrere gleichzeitig möglich), rendert nichts wenn keine aktiv ist.
- Neuer Admin-Bereich `AnnouncementsView.vue` (`/app/announcements`, nur für Admins) mit Liste aller Ankündigungen (inkl. abgelaufener mit Status-Badge), Rich-Text-Editor (bestehende `HtmlEditor.vue`) und Bild-Upload (bestehende `FileUpload.vue`).
- Keine neuen Composer-/npm-Abhängigkeiten — bestehendes Sanitizing-Trait, Rich-Text-Editor und DOMPurify-Muster wiederverwendet.

## Workflow
Vollständiger Workflow durchlaufen: triage → architect (proposal/design/tasks/specs) → skeptic (2 Punkte widerlegt und korrigiert) → User-Gate 1 → Implementierung (T01–T11, dev-php + dev-typescript) → reviewer + tester parallel (1 Blocker gefunden und behoben: geteilter error-Ref versteckte die Ankündigungsliste bei fehlgeschlagenen Mutationen) → architect Abnahme (Modus B) → User-Gate 2 → archiviert, Spec `announcement-management` neu angelegt.

Details siehe `openspec/changes/archive/2026-07-17-add-announcement-banner/` (proposal.md, design.md, verification.md, acceptance.md, task-*.notes.md, test-report.md).

## Test plan
- [x] Backend: `docker compose exec php vendor/bin/pest` — 718 Tests grün
- [x] Frontend: `npm run test` — 191 Tests grün
- [x] Frontend: `npm run build` — kein TypeScript-/Build-Fehler
- [x] Migration gegen PostgreSQL und MySQL getestet (Ad-hoc-Container, da `docker-compose.mysql.yml` im Repo fehlt)
- [ ] Manuelles Durchklicken im Browser (Landingpage-Banner + Admin-Formular) vor Merge empfohlen

🤖 Generated with [Claude Code](https://claude.com/claude-code)