### PR TITLE
PDF-Download-Button im Anamnese-Detail-Modal ergänzen

### DIFF
--- a/frontend/src/components/anamnesis/AnamnesisDetailModal.vue
+++ b/frontend/src/components/anamnesis/AnamnesisDetailModal.vue
@@ -88,7 +88,16 @@
 
             <!-- Footer -->
             <div class="sticky bottom-0 bg-gray-50 dark:bg-gray-700 px-6 py-4 rounded-b-xl border-t border-gray-200 dark:border-gray-700">
-              <div class="flex justify-end">
+              <div class="flex justify-end gap-2">
+                <button
+                  v-if="details"
+                  type="button"
+                  @click="downloadPdf"
+                  :disabled="pdfDownloading"
+                  class="btn btn-secondary"
+                >
+                  {{ pdfDownloading ? 'Wird heruntergeladen...' : 'PDF herunterladen' }}
+                </button>
                 <button type="button" @click="close" class="btn btn-primary">
                   Schließen
                 </button>
@@ -118,6 +127,7 @@ const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
 const loading = ref(false)
+const pdfDownloading = ref(false)
 const details = ref<AnamnesisResponse | null>(null)
 
 watch(() => props.modelValue, async (newValue) => {
@@ -160,6 +170,25 @@ function formatAnswer(value: string) {
     // Not JSON, return as-is
   }
   return value
+}
+
+async function downloadPdf() {
+  if (!details.value) return
+
+  pdfDownloading.value = true
+  try {
+    const blob = await anamnesisResponsesApi.downloadPdf(details.value.id)
+    const url = window.URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `anamnesis-${details.value.id}.pdf`
+    link.click()
+    window.URL.revokeObjectURL(url)
+  } catch (error) {
+    console.error('Error downloading PDF:', error)
+  } finally {
+    pdfDownloading.value = false
+  }
 }
 
 function close() {

--- a/openspec/triage/20260723093849-anamnese-pdf-export.md
+++ b/openspec/triage/20260723093849-anamnese-pdf-export.md
@@ -1,0 +1,69 @@
+# Triage: Anamnese PDF-Export
+
+**Pfad:** trivial
+**Geschätzter Umfang:** 1 Datei, TypeScript/Vue
+**Risiko:** niedrig — Backend vollständig implementiert, keine Schnittstellen-Änderungen notwendig
+**Klarheit:** klar — Anforderung ist eindeutig, fast alles bereits implementiert
+
+## Anforderung (Zusammenfassung)
+Als Trainer soll es möglich sein, ausgefüllte Anamnesefragebögen als PDF herunterzuladen oder auszudrucken.
+Die Anforderung ist faktisch bereits zu ~90 % implementiert: Backend-Endpoint, Blade-Template, API-Layer und ein
+PDF-Button in der Listen-Ansicht sind vorhanden. Einzig im Detail-Modal (`AnamnesisDetailModal.vue`) fehlt noch
+ein Download-Button, sodass Trainer von der Detail-Ansicht aus kein PDF auslösen können.
+
+## Bestandsaufnahme: Was bereits existiert
+
+### Backend (vollständig implementiert)
+| Datei | Status |
+|---|---|
+| `backend/app/Http/Controllers/AnamnesisResponseController.php` | `downloadPdf()` vorhanden, nutzt `barryvdh/laravel-dompdf` |
+| `backend/routes/api.php` (Z. 155) | Route `GET /api/v1/anamnesis-responses/{id}/pdf` registriert |
+| `backend/resources/views/pdf/anamnesis.blade.php` | Blade-Template vorhanden |
+| `backend/tests/Feature/AnamnesisResponsePdfTest.php` | Vollständige Tests (Auth, Content, Download-Header) vorhanden |
+
+### Frontend (fast vollständig)
+| Datei | Status |
+|---|---|
+| `frontend/src/api/anamnesis.ts` (Z. 194) | `downloadPdf(id)` implementiert |
+| `frontend/src/views/anamnesis/AnamnesisView.vue` (Z. 80, 325–336) | PDF-Button in Listen-View + `downloadPdf()`-Funktion vorhanden |
+| `frontend/src/components/anamnesis/AnamnesisDetailModal.vue` | **FEHLT:** kein PDF-Button im Footer |
+
+### Vorhandene PDF-Bibliotheken
+- `barryvdh/laravel-dompdf: ^3.1` (in `backend/composer.json`) — bereits installiert und in Verwendung
+
+### Bestehende Specs
+Kein dedizierter `anamnesis-pdf-export`-Spec vorhanden. Anamnese-Specs:
+- `openspec/specs/anamnesis-template-management/spec.md`
+- `openspec/specs/anamnesis-answer-question-text/spec.md`
+- `openspec/specs/anamnesis-response-display-fields/spec.md`
+
+## Fehlende Implementierung
+
+**Einzige Lücke:** `AnamnesisDetailModal.vue` Footer — PDF-Download-Button ergänzen.
+
+```vue
+<\!-- Im Footer der Modal-Komponente, neben "Schließen"-Button -->
+<button @click="downloadPdf" class="btn btn-secondary mr-2">PDF herunterladen</button>
+```
+
+Die `downloadPdf()`-Logik kann direkt aus `AnamnesisView.vue` (Z. 325–336) übernommen werden
+und nutzt `anamnesisResponsesApi.downloadPdf(props.anamnesisResponse.id)`.
+
+## Risiken / Besonderheiten
+
+- **Shared Hosting:** DomPDF läuft rein in PHP (kein Shell-Exec, kein Node) — vollständig shared-hosting-kompatibel ✓
+- **PHP 8.2 Kompatibilität:** `barryvdh/laravel-dompdf ^3.1` unterstützt PHP 8.2 ✓
+- **MySQL-Kompatibilität:** Nur Eloquent-Abfragen, kein raw SQL ✓
+- **Authorization:** Tests zeigen, dass Admin *keinen* Zugriff hat — nur Trainer und zugehörige Kunden. Frontend muss ggf. den Button nur für autorisierte Rollen anzeigen.
+- **Drucken-Option:** Die Anforderung erwähnt auch "direkt ausdrucken". Das kann entweder über `window.print()` im Browser-PDF-Viewer (nativ nach Download) oder als separater `print`-Button mit `window.open(url)` umgesetzt werden — kein aufwändiges Eigenbau nötig.
+
+## Empfohlene nächste Aktion
+
+**Direkt von `dev-typescript` umzusetzen (kein Architekt nötig):**
+
+1. `frontend/src/components/anamnesis/AnamnesisDetailModal.vue` — PDF-Download-Button im Footer ergänzen
+2. Rolle prüfen: Button nur für Trainer anzeigen (oder für den eigenen Kunden)
+3. Ladeindikator während des Downloads optional (analog zu `AnamnesisView.vue`)
+4. Kein neuer Spec nötig (Lücke in bestehender Implementierung)
+
+Nach Umsetzung: `npm run lint && npm run test && npm run build` als Pre-Flight.


### PR DESCRIPTION
## Summary
- Ergänzt einen PDF-Download-Button im Footer des Anamnese-Detail-Modals (`AnamnesisDetailModal.vue`)
- Nutzt dieselbe `downloadPdf()`-Logik, die bereits in `AnamnesisView.vue` für den Listen-Export vorhanden ist
- Backend-Endpoint, Blade-Template und Tests für den PDF-Export existierten bereits vollständig — es fehlte lediglich der Button im Detail-Modal

## Test plan
- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build` (Lauffähigkeits-Check)
- [ ] Manuell: Anamnese-Detail-Modal öffnen, PDF-Download-Button klicken, PDF prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)