### PR TITLE
fix: Firmenadresse in E-Mail-Layout aus Einstellungen lesen

### DIFF
--- a/backend/resources/views/layouts/email.blade.php
+++ b/backend/resources/views/layouts/email.blade.php
@@ -155,7 +155,7 @@
                     <div class="email-footer">
                         <p><strong>{{ $settings['company_name'] ?? 'Hundeschule Mustermann' }}</strong></p>
                         <p>
-                            {{ $settings['company_address'] ?? 'Musterstraße 123' }}<br>
+                            {{ $settings['company_street'] ?? 'Musterstraße 123' }}<br>
                             {{ $settings['company_zip'] ?? '12345' }} {{ $settings['company_city'] ?? 'Musterstadt' }}
                         </p>
                         <p>


### PR DESCRIPTION
## Summary
- Das gemeinsame Mail-Layout (`backend/resources/views/layouts/email.blade.php`) griff auf den Settings-Key `company_address` zu, gespeichert wird die Straße aber unter `company_street` (siehe `SettingsSeeder`, `UpdateSettingsRequest`, `SettingsController`).
- Dadurch griff in allen über dieses Layout versendeten Systemmails (u. a. der Kontaktformular-Benachrichtigung) immer der hartkodierte Fallback `Musterstraße 123` statt der in den Einstellungen hinterlegten Adresse.
- Fix: Key in Zeile 158 auf `company_street` korrigiert.

## Test plan
- [x] `composer qa` (Lint, PHPStan, PHPCompatibility gegen PHP 8.2, Pest) — 722 Tests grün
- [x] Diff manuell geprüft: nur der Settings-Key geändert, restliche Keys (`company_zip`, `company_city`, `company_phone`, `company_email`, `company_website`) bereits korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)