### PR TITLE
fix: flakigen Kunden-Suchfilter-Test deterministisch machen

### DIFF
--- a/backend/tests/Feature/Api/CustomerApiTest.php
+++ b/backend/tests/Feature/Api/CustomerApiTest.php
@@ -69,10 +69,10 @@ describe('Customer API - Index', function () {
     test('can filter customers by search term', function () {
         $admin = User::factory()->admin()->create();
 
-        $user1 = User::factory()->create(['first_name' => 'John', 'last_name' => 'Doe']);
+        $user1 = User::factory()->create(['first_name' => 'John', 'last_name' => 'Doe', 'email' => 'john.doe@example.test']);
         $customer1 = Customer::factory()->create(['user_id' => $user1->id]);
 
-        $user2 = User::factory()->create(['first_name' => 'Jane', 'last_name' => 'Smith']);
+        $user2 = User::factory()->create(['first_name' => 'Jane', 'last_name' => 'Smith', 'email' => 'jane.smith@example.test']);
         $customer2 = Customer::factory()->create(['user_id' => $user2->id]);
 
         $response = $this->actingAs($admin)


### PR DESCRIPTION
## Summary

Während der Untersuchung eines fehlgeschlagenen PostgreSQL-CI-Laufs auf PR #86 gefunden — betrifft keine der dortigen Änderungen (Testdatei ist byte-identisch mit `main`).

`CustomerApiTest::'can filter customers by search term'` erwartet, dass die Suche nach "John" genau einen Treffer liefert. Der zweite (nicht-treffende) Testkunde "Jane Smith" bekommt aber keine explizite E-Mail-Adresse — die kommt zufällig von Faker. Die Backend-Suche filtert über `first_name`, `last_name` **und `email`** (case-insensitive). Enthält die zufällig generierte E-Mail zufällig die Zeichenfolge "john" (z.B. über einen Nachnamen wie "Johnson" aus Fakers Namenspool), matcht sie ungewollt mit — der Test schlägt dann intermittierend fehl, unabhängig vom sonstigen Code.

**Beleg für Flakiness:** Derselbe Commit auf `feature/add-invoice-send-flow` lief in einem CI-Run grün, im nächsten (identischer Code) rot.

Fix: beide Kunden-E-Mails im Test explizit setzen statt sie Faker zu überlassen.

## Test plan

- [x] `vendor/bin/pest --filter=CustomerApiTest` 3× hintereinander gegen echtes PostgreSQL ausgeführt, immer grün
- [x] `vendor/bin/pest --no-coverage` (komplette Suite) grün — 813 Tests
- [x] `composer lint` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)