### PR TITLE
fix: Broken Access Control bei Zahlungsdaten (IDOR)

### DIFF
--- a/backend/app/Http/Controllers/Api/PaymentController.php
+++ b/backend/app/Http/Controllers/Api/PaymentController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StorePaymentRequest;
 use App\Http\Requests\UpdatePaymentRequest;
 use App\Http\Resources\PaymentResource;
+use App\Models\Customer;
 use App\Models\Invoice;
 use App\Models\Payment;
 use App\Services\PayPalService;
@@ -45,6 +46,28 @@ class PaymentController extends Controller
     public function index(Request $request): AnonymousResourceCollection
     {
         $query = Payment::query()->with(['invoice.customer.user']);
+
+        $user = $request->user();
+
+        // Role-based filtering
+        if ($user->isTrainer()) {
+            // Trainer sees only payments for invoices of their assigned customers
+            $query->whereHas('invoice.customer', function ($q) use ($user) {
+                $q->where('trainer_id', $user->id);
+            });
+        } elseif ($user->isCustomer()) {
+            // Customer sees only payments for their own invoices
+            $customer = Customer::where('user_id', $user->id)->first();
+            if ($customer) {
+                $query->whereHas('invoice', function ($q) use ($customer) {
+                    $q->where('customer_id', $customer->id);
+                });
+            } else {
+                // No customer record means no payments
+                $query->whereRaw('1 = 0');
+            }
+        }
+        // Admin sees everything (no filter)
 
         // Filter by invoice
         if ($request->has('invoiceId')) {

--- a/backend/app/Policies/PaymentPolicy.php
+++ b/backend/app/Policies/PaymentPolicy.php
@@ -25,12 +25,22 @@ class PaymentPolicy
 
     /**
      * Determine whether the user can view the payment.
+     *
+     * Trainers may only view payments whose invoice belongs to one of their
+     * own assigned customers (`Customer::trainer_id === $user->id`) — the
+     * same scoping rule already applied to `PaymentController::index()`, so
+     * a trainer cannot fetch a foreign customer's payment by guessing/
+     * enumerating its id.
      */
     public function view(User $user, Payment $payment): bool
     {
-        // Admins and trainers can view any payment
-        if ($user->isAdminOrTrainer()) {
+        // Admins can view any payment
+        if ($user->isAdmin()) {
             return true;
+        }
+
+        if ($user->isTrainer()) {
+            return $payment->invoice->customer->trainer_id === $user->id;
         }
 
         // Customers can only view their own invoice's payments
@@ -48,15 +58,26 @@ class PaymentPolicy
 
     /**
      * Determine whether the user can update the payment.
+     *
+     * Same trainer-scoping rule as {@see self::view()}: a trainer may only
+     * update payments belonging to their own assigned customers. Customers
+     * are never allowed to update payments (unchanged).
      */
     public function update(User $user, Payment $payment): bool
     {
-        // Only admins and trainers can update payments
-        return $user->isAdminOrTrainer();
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        return $user->isTrainer() && $payment->invoice->customer->trainer_id === $user->id;
     }
 
     /**
      * Determine whether the user can delete the payment.
+     *
+     * Only admins can delete payments — trainers have no delete permission
+     * at all, so no trainer-scoping is needed here (unlike {@see self::view()}
+     * and {@see self::update()}).
      */
     public function delete(User $user, Payment $payment): bool
     {

--- a/backend/tests/Feature/PaymentApiTest.php
+++ b/backend/tests/Feature/PaymentApiTest.php
@@ -54,6 +54,86 @@ test('customer can list payments for their invoices', function () {
     expect($response->json('data'))->toHaveCount(2);
 });
 
+test('customer cannot see other customers payments in unfiltered list', function () {
+    Payment::factory()->count(2)->create(['invoice_id' => $this->invoice->id]);
+
+    $otherCustomerUser = User::factory()->create(['role' => 'customer']);
+    $otherCustomer = Customer::factory()->create(['user_id' => $otherCustomerUser->id]);
+    $otherInvoice = Invoice::factory()->create(['customer_id' => $otherCustomer->id]);
+    Payment::factory()->count(3)->create(['invoice_id' => $otherInvoice->id]);
+
+    $response = $this->actingAs($this->customerUser)
+        ->getJson('/api/v1/payments')
+        ->assertOk();
+
+    expect($response->json('data'))->toHaveCount(2);
+    foreach ($response->json('data') as $payment) {
+        expect($payment['invoice']['id'])->toBe($this->invoice->id);
+    }
+});
+
+test('customer cannot access other customers payments by manipulating invoiceId filter', function () {
+    $otherCustomerUser = User::factory()->create(['role' => 'customer']);
+    $otherCustomer = Customer::factory()->create(['user_id' => $otherCustomerUser->id]);
+    $otherInvoice = Invoice::factory()->create(['customer_id' => $otherCustomer->id]);
+    Payment::factory()->count(3)->create(['invoice_id' => $otherInvoice->id]);
+
+    $response = $this->actingAs($this->customerUser)
+        ->getJson('/api/v1/payments?invoiceId='.$otherInvoice->id)
+        ->assertOk();
+
+    expect($response->json('data'))->toHaveCount(0);
+});
+
+test('customer without customer record sees no payments', function () {
+    $customerUserWithoutRecord = User::factory()->create(['role' => 'customer']);
+    Payment::factory()->count(3)->create(['invoice_id' => $this->invoice->id]);
+
+    $response = $this->actingAs($customerUserWithoutRecord)
+        ->getJson('/api/v1/payments')
+        ->assertOk();
+
+    expect($response->json('data'))->toHaveCount(0);
+});
+
+test('trainer only sees payments for their assigned customers', function () {
+    Payment::factory()->count(2)->create(['invoice_id' => $this->invoice->id]);
+    $this->customer->update(['trainer_id' => $this->trainer->id]);
+
+    $otherTrainer = User::factory()->create(['role' => 'trainer']);
+    $otherCustomerUser = User::factory()->create(['role' => 'customer']);
+    $otherCustomer = Customer::factory()->create([
+        'user_id' => $otherCustomerUser->id,
+        'trainer_id' => $otherTrainer->id,
+    ]);
+    $otherInvoice = Invoice::factory()->create(['customer_id' => $otherCustomer->id]);
+    Payment::factory()->count(3)->create(['invoice_id' => $otherInvoice->id]);
+
+    $response = $this->actingAs($this->trainer)
+        ->getJson('/api/v1/payments')
+        ->assertOk();
+
+    expect($response->json('data'))->toHaveCount(2);
+    foreach ($response->json('data') as $payment) {
+        expect($payment['invoice']['id'])->toBe($this->invoice->id);
+    }
+});
+
+test('admin can still list all payments regardless of customer or trainer', function () {
+    Payment::factory()->count(2)->create(['invoice_id' => $this->invoice->id]);
+
+    $otherCustomerUser = User::factory()->create(['role' => 'customer']);
+    $otherCustomer = Customer::factory()->create(['user_id' => $otherCustomerUser->id]);
+    $otherInvoice = Invoice::factory()->create(['customer_id' => $otherCustomer->id]);
+    Payment::factory()->count(3)->create(['invoice_id' => $otherInvoice->id]);
+
+    $response = $this->actingAs($this->admin)
+        ->getJson('/api/v1/payments')
+        ->assertOk();
+
+    expect($response->json('data'))->toHaveCount(5);
+});
+
 test('payments can be filtered by payment method', function () {
     Payment::factory()->count(2)->create(['payment_method' => 'cash']);
     Payment::factory()->count(3)->create(['payment_method' => 'stripe']);
@@ -87,13 +167,29 @@ test('can get only completed payments', function () {
     expect($response->json('data'))->toHaveCount(3);
 });
 
-test('trainer can view any payment', function () {
-    $payment = Payment::factory()->create();
+test('trainer can view payment for their assigned customer', function () {
+    $this->customer->update(['trainer_id' => $this->trainer->id]);
+    $payment = Payment::factory()->create(['invoice_id' => $this->invoice->id]);
 
     $this->actingAs($this->trainer)
         ->getJson('/api/v1/payments/'.$payment->id)
         ->assertOk()
         ->assertJsonPath('data.id', $payment->id);
+});
+
+test('trainer cannot view payment for other trainers customer', function () {
+    $otherTrainer = User::factory()->create(['role' => 'trainer']);
+    $otherCustomerUser = User::factory()->create(['role' => 'customer']);
+    $otherCustomer = Customer::factory()->create([
+        'user_id' => $otherCustomerUser->id,
+        'trainer_id' => $otherTrainer->id,
+    ]);
+    $otherInvoice = Invoice::factory()->create(['customer_id' => $otherCustomer->id]);
+    $payment = Payment::factory()->create(['invoice_id' => $otherInvoice->id]);
+
+    $this->actingAs($this->trainer)
+        ->getJson('/api/v1/payments/'.$payment->id)
+        ->assertForbidden();
 });
 
 test('customer can view payment for their invoice', function () {
@@ -231,8 +327,9 @@ test('payment method must be valid', function () {
         ->assertJsonValidationErrors(['paymentMethod']);
 });
 
-test('trainer can update payment', function () {
-    $payment = Payment::factory()->create(['status' => 'pending']);
+test('trainer can update payment for their assigned customer', function () {
+    $this->customer->update(['trainer_id' => $this->trainer->id]);
+    $payment = Payment::factory()->create(['invoice_id' => $this->invoice->id, 'status' => 'pending']);
 
     $this->actingAs($this->trainer)
         ->putJson('/api/v1/payments/'.$payment->id, [
@@ -250,6 +347,28 @@ test('trainer can update payment', function () {
     ]);
 });
 
+test('trainer cannot update payment for other trainers customer', function () {
+    $otherTrainer = User::factory()->create(['role' => 'trainer']);
+    $otherCustomerUser = User::factory()->create(['role' => 'customer']);
+    $otherCustomer = Customer::factory()->create([
+        'user_id' => $otherCustomerUser->id,
+        'trainer_id' => $otherTrainer->id,
+    ]);
+    $otherInvoice = Invoice::factory()->create(['customer_id' => $otherCustomer->id]);
+    $payment = Payment::factory()->create(['invoice_id' => $otherInvoice->id, 'status' => 'pending']);
+
+    $this->actingAs($this->trainer)
+        ->putJson('/api/v1/payments/'.$payment->id, [
+            'status' => 'completed',
+        ])
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('payments', [
+        'id' => $payment->id,
+        'status' => 'pending',
+    ]);
+});
+
 test('customer cannot update payment', function () {
     $payment = Payment::factory()->create(['invoice_id' => $this->invoice->id]);
 
@@ -261,7 +380,8 @@ test('customer cannot update payment', function () {
 });
 
 test('trainer can mark payment as completed', function () {
-    $payment = Payment::factory()->create(['status' => 'pending']);
+    $this->customer->update(['trainer_id' => $this->trainer->id]);
+    $payment = Payment::factory()->create(['invoice_id' => $this->invoice->id, 'status' => 'pending']);
 
     $this->actingAs($this->trainer)
         ->postJson('/api/v1/payments/'.$payment->id.'/mark-completed')
@@ -275,7 +395,8 @@ test('trainer can mark payment as completed', function () {
 });
 
 test('cannot mark already completed payment', function () {
-    $payment = Payment::factory()->create(['status' => 'completed']);
+    $this->customer->update(['trainer_id' => $this->trainer->id]);
+    $payment = Payment::factory()->create(['invoice_id' => $this->invoice->id, 'status' => 'completed']);
 
     $this->actingAs($this->trainer)
         ->postJson('/api/v1/payments/'.$payment->id.'/mark-completed')
@@ -283,8 +404,25 @@ test('cannot mark already completed payment', function () {
         ->assertJsonPath('message', 'Zahlung ist bereits abgeschlossen.');
 });
 
+test('trainer cannot mark payment as completed for other trainers customer', function () {
+    $otherTrainer = User::factory()->create(['role' => 'trainer']);
+    $otherCustomerUser = User::factory()->create(['role' => 'customer']);
+    $otherCustomer = Customer::factory()->create([
+        'user_id' => $otherCustomerUser->id,
+        'trainer_id' => $otherTrainer->id,
+    ]);
+    $otherInvoice = Invoice::factory()->create(['customer_id' => $otherCustomer->id]);
+    $payment = Payment::factory()->create(['invoice_id' => $otherInvoice->id, 'status' => 'pending']);
+
+    $this->actingAs($this->trainer)
+        ->postJson('/api/v1/payments/'.$payment->id.'/mark-completed')
+        ->assertForbidden();
+});
+
 test('marking payment completed updates invoice status if fully paid', function () {
+    $this->customer->update(['trainer_id' => $this->trainer->id]);
     $invoice = Invoice::factory()->create([
+        'customer_id' => $this->customer->id,
         'total_amount' => 150.00,
         'status' => 'sent',
     ]);

--- a/docs/security-fixes/payment-authorization-scope.md
+++ b/docs/security-fixes/payment-authorization-scope.md
@@ -1,0 +1,169 @@
+# Security Fix: Broken Access Control (IDOR) on the Payment endpoints
+
+This document covers two related Broken Access Control (IDOR) fixes for the
+`Payment` API — the same root cause (trainer-scoping was missing/incomplete
+across `PaymentPolicy`/`PaymentController`), fixed in two passes on the
+`fix/payment-index-missing-authorization-scope` branch:
+
+1. [Part 1 — `GET /api/v1/payments` (list)](#part-1--get-apiv1payments-list)
+2. [Part 2 — `GET`/`PUT /api/v1/payments/{id}` (single-record)](#part-2--get-put-apiv1paymentsid-single-record)
+
+## Part 1 — `GET /api/v1/payments` (list)
+
+### Problem
+
+`PaymentController::index()`
+(`backend/app/Http/Controllers/Api/PaymentController.php`) built its query
+purely from optional request filters (`invoiceId`, `paymentMethod`,
+`status`, `completedOnly`, `startDate`/`endDate`) and never scoped the
+result set to the authenticated user (`$request->user()`).
+
+Consequence: **any** authenticated user — including customers — could call
+`GET /api/v1/payments` and see payment records (amounts, dates, payment
+method) belonging to **other** customers, either in the unfiltered list or
+by guessing/enumerating a foreign `invoiceId` via the `invoiceId` query
+parameter. This is a classic Insecure Direct Object Reference / Broken
+Access Control issue (OWASP API1:2023 / A01:2021).
+
+`PaymentPolicy::viewAny()` returned `true` unconditionally and was not used
+to enforce any row-level scoping — the policy only gated `store`, `update`,
+`delete` and the single-record `show()` (`PaymentPolicy::view()`). At the
+time of this fix, `view()`'s customer branch was correctly scoped to the
+payment's invoice's customer, but its trainer branch was not — see
+[Part 2](#part-2--get-put-apiv1paymentsid-single-record) below, which closes
+that gap.
+
+### Fix
+
+`PaymentController::index()` now applies the same role-based query scoping
+that `InvoiceController::index()` already uses for invoices, adapted to the
+`Payment` → `Invoice` → `Customer` relationship chain:
+
+- **Trainer**: only sees payments whose invoice belongs to a customer with
+  `trainer_id === $user->id` (`whereHas('invoice.customer', ...)`).
+- **Customer**: only sees payments whose invoice belongs to their own
+  `Customer` record (resolved via `Customer::where('user_id', $user->id)`).
+  If no `Customer` record exists for the user, the query is forced to
+  return zero rows (`whereRaw('1 = 0')`), mirroring the equivalent
+  `InvoiceController` behavior — no exception is thrown.
+- **Admin**: no additional filter (sees everything), unchanged.
+
+The existing optional query filters (`invoiceId`, `paymentMethod`,
+`status`, `completedOnly`, `startDate`, `endDate`) are applied **in
+addition to** the role scope, so a customer/trainer can no longer bypass
+the scope by passing a foreign `invoiceId` — the `whereHas` scope and the
+`invoiceId` filter are combined with `AND`, and a non-matching `invoiceId`
+simply yields an empty result instead of exposing foreign data.
+
+`PaymentPolicy::viewAny()` was left as `return true;` (every authenticated
+user may call the endpoint at all — mirroring `InvoiceController::index()`,
+which also has no explicit `viewAny` policy check), since the actual
+row-level authorization now happens in the query itself, not in the
+policy.
+
+### Files changed
+
+- `backend/app/Http/Controllers/Api/PaymentController.php` — added
+  role-based query scoping in `index()`, added `use App\Models\Customer;`.
+- `backend/tests/Feature/PaymentApiTest.php` — added regression tests.
+
+### Tests added (`backend/tests/Feature/PaymentApiTest.php`)
+
+- `customer cannot see other customers payments in unfiltered list` —
+  asserts a customer's unfiltered `GET /api/v1/payments` only returns
+  payments for their own invoice.
+- `customer cannot access other customers payments by manipulating
+  invoiceId filter` — asserts passing a foreign `invoiceId` returns an
+  empty list instead of the foreign customer's payments.
+- `customer without customer record sees no payments` — asserts a
+  customer-role user without an associated `Customer` record gets an empty
+  list (no exception).
+- `trainer only sees payments for their assigned customers` — asserts a
+  trainer only sees payments for invoices of customers with matching
+  `trainer_id`, not payments belonging to another trainer's customers.
+- `admin can still list all payments regardless of customer or trainer` —
+  regression guard that the admin's unrestricted view still works after
+  adding the scope.
+
+The pre-existing test `customer can list payments for their invoices` was
+kept unchanged; it covers the positive filter case but not isolation
+against foreign payments, which is why the new tests above were added
+alongside it.
+
+### Verification
+
+- `composer lint`, `composer stan`, `composer compat-check` — all green.
+- `vendor/bin/pest --no-coverage --filter=PaymentApiTest` — 28 passed.
+- Full suite `composer test` — 838 passed (2617 assertions), no
+  regressions in other feature tests (e.g. `InvoiceApiTest`, PayPal flows).
+
+## Part 2 — `GET`/`PUT /api/v1/payments/{id}` (single-record)
+
+### Problem
+
+`PaymentPolicy::view()` and `PaymentPolicy::update()` only checked
+`$user->isAdminOrTrainer()` for the trainer role, without verifying that the
+payment's customer was actually assigned to *that* trainer
+(`Customer::trainer_id === $user->id`). This is the same Broken Access
+Control class as Part 1, just on the single-record endpoints instead of the
+list endpoint.
+
+Consequence: Trainer A could call `GET /api/v1/payments/{id}` and
+`PUT /api/v1/payments/{id}` for a payment belonging to a customer assigned
+to Trainer B, and both view and modify (e.g. change `status`, mark
+completed) that payment — a foreign-trainer IDOR that Part 1's list-endpoint
+fix did not close, because `show()`/`update()` operate on a single record
+resolved via route-model-binding rather than a filtered query.
+
+`PaymentPolicy::delete()` was already admin-only (`$user->isAdmin()`);
+trainers have no delete permission at all, so there is no trainer-scoping
+question there and it was left unchanged.
+
+### Fix
+
+`PaymentPolicy::view()` and `PaymentPolicy::update()` now apply the same
+`Payment` → `Invoice` → `Customer` trainer-scoping rule as the `index()`
+fix from Part 1:
+
+- **Admin**: unchanged, may view/update any payment.
+- **Trainer**: may only view/update a payment if
+  `$payment->invoice->customer->trainer_id === $user->id`.
+- **Customer**: `view()` unchanged (own invoice's payments only, via
+  `user_id`); `update()` unchanged — customers were never allowed to update
+  payments and still are not (that policy question was explicitly out of
+  scope for this fix).
+
+### Files changed
+
+- `backend/app/Policies/PaymentPolicy.php` — added trainer-scoping to
+  `view()` and `update()`.
+- `backend/tests/Feature/PaymentApiTest.php` — added regression tests;
+  adjusted pre-existing trainer tests (`show`, `update`,
+  `mark-completed`) that previously relied on unscoped trainer access to
+  explicitly assign the trainer to the payment's customer, since they would
+  otherwise now fail with 403.
+
+### Tests added/adjusted (`backend/tests/Feature/PaymentApiTest.php`)
+
+- `trainer can view payment for their assigned customer` (renamed from
+  `trainer can view any payment`) — scopes the customer to the trainer and
+  asserts the existing positive case still works.
+- `trainer cannot view payment for other trainers customer` — new,
+  asserts 403 for a payment belonging to another trainer's customer.
+- `trainer can update payment for their assigned customer` (renamed from
+  `trainer can update payment`) — same scoping adjustment.
+- `trainer cannot update payment for other trainers customer` — new,
+  asserts 403 and that the payment's `status` was not changed.
+- `trainer can mark payment as completed`, `cannot mark already completed
+  payment`, `marking payment completed updates invoice status if fully
+  paid` — adjusted to scope the customer to the trainer, since
+  `markAsCompleted()` also authorizes via `update`.
+- `trainer cannot mark payment as completed for other trainers customer` —
+  new, asserts 403 for a foreign trainer's customer.
+
+### Verification
+
+- `composer lint`, `composer stan`, `composer compat-check` — all green.
+- `vendor/bin/pest --no-coverage --filter=PaymentApiTest` — 31 passed.
+- Full suite `composer test` — 841 passed (2621 assertions), no
+  regressions in other feature tests.


### PR DESCRIPTION
## Summary

Sicherheits-Fix, entdeckt während der Spezifikation von Change 3 (`add-invoice-payment-entry`) im Rechnungsworkflow-Umbau, aber unabhängig davon und dringlicher.

**Problem:** `GET /api/v1/payments` filterte die Ergebnisliste nicht nach dem angemeldeten Nutzer — jeder authentifizierte Kunde konnte Zahlungsdaten (Betrag, Datum, Zahlungsart) **anderer** Kunden einsehen, entweder direkt in der unbefilterten Liste oder gezielt über einen fremden `invoiceId`-Query-Parameter. Zusätzlich prüften `PaymentPolicy::view()`/`update()` beim Einzelzugriff (`GET`/`PUT /api/v1/payments/{id}`) nur die Rolle ("ist Trainer"), nicht die tatsächliche Kundenzuordnung — ein Trainer konnte dadurch Zahlungen von Kunden anderer Trainer einsehen und ändern.

**Fix:**
- `PaymentController::index()`: Rollen-basiertes Scoping ergänzt, analog zum bestehenden Muster in `InvoiceController::index()` (Trainer → nur zugewiesene Kunden, Kunde → nur eigene, Admin → alles). Die bestehenden optionalen Filter (`invoiceId`, `paymentMethod`, etc.) bleiben zusätzlich per `AND` wirksam, ein fremder `invoiceId` liefert jetzt eine leere statt einer fremden Liste.
- `PaymentPolicy::view()`/`update()`: Trainer-Zugriff jetzt zusätzlich an `Customer.trainer_id === $user->id` gebunden. `delete()` bleibt unverändert (ohnehin nur Admin).

## Test plan

- [x] `vendor/bin/pest --no-coverage` grün — 841 Tests, 2621 Assertions
- [x] `composer lint`/`stan`/`compat-check` grün
- [x] Neue gezielte Tests: Kunde A sieht weder ungefiltert noch über fremde `invoiceId` Zahlungen von Kunde B; Kunde ohne Customer-Datensatz bekommt leere Liste statt Fehler; Trainer sieht/ändert nur Zahlungen zugewiesener Kunden, bekommt 403 bei fremden; Admin-Regressionsschutz (sieht weiterhin alles)
- [x] Unabhängiger Security-Review durchgeführt, keine Muss-Befunde

🤖 Generated with [Claude Code](https://claude.com/claude-code)