### PR TITLE
fix: PayPal-Webhook durch doppelten Präfix unerreichbar

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -70,7 +70,9 @@ Route::prefix('v1')->middleware('throttle:60,1')->group(function () {
 });
 
 // PayPal webhook - separate without rate limiting (PayPal needs reliable access)
-Route::post('/api/v1/payments/paypal/webhook', [PaymentController::class, 'handleWebhook']);
+Route::prefix('v1')->group(function () {
+    Route::post('/payments/paypal/webhook', [PaymentController::class, 'handleWebhook']);
+});
 
 // Protected routes
 Route::prefix('v1')->middleware('auth:sanctum')->group(function () {

--- a/backend/tests/Feature/PaymentApiTest.php
+++ b/backend/tests/Feature/PaymentApiTest.php
@@ -330,3 +330,16 @@ test('trainer cannot delete payment', function () {
         ->deleteJson('/api/v1/payments/'.$payment->id)
         ->assertForbidden();
 });
+
+test('paypal webhook is reachable at the external path PayPal is configured with, without authentication', function () {
+    // Regression test: the route was previously double-prefixed
+    // ("/api" + implicit "/api" from bootstrap/app.php), resulting in
+    // "/api/api/v1/payments/paypal/webhook" - a path PayPal could never
+    // reach. This asserts the exact URL PayPal is configured to call.
+    $this->postJson('/api/v1/payments/paypal/webhook', [
+        'event_type' => 'PAYMENT.CAPTURE.COMPLETED',
+        'resource' => ['id' => 'UNKNOWN-TRANSACTION-ID'],
+    ])
+        ->assertOk()
+        ->assertJsonPath('status', 'success');
+});

--- a/docs/security-fixes/paypal-webhook-double-prefix.md
+++ b/docs/security-fixes/paypal-webhook-double-prefix.md
@@ -1,0 +1,83 @@
+# Fix: PayPal-Webhook-Route doppelt präfixiert
+
+## Status
+
+Behoben.
+
+## Betroffene Datei
+
+- `backend/routes/api.php`
+
+## Problem
+
+`backend/bootstrap/app.php` registriert `routes/api.php` über
+`Application::configure()->withRouting(api: __DIR__.'/../routes/api.php', ...)`.
+Laravel versieht alle darin definierten Routen automatisch mit dem Präfix
+`/api`. Alle anderen Routen der Datei berücksichtigen das korrekt, indem sie
+zusätzlich in `Route::prefix('v1')->group(...)`-Blöcke gekapselt sind
+(effektiver Pfad z. B. `/api/v1/pricing-items`).
+
+Die PayPal-Webhook-Route war davon abweichend mit einem hartkodierten,
+vollständigen Pfad registriert:
+
+```php
+Route::post('/api/v1/payments/paypal/webhook', [PaymentController::class, 'handleWebhook']);
+```
+
+Dadurch ergab sich der effektive, nach außen sichtbare Pfad
+`/api/api/v1/payments/paypal/webhook` (doppeltes `/api`-Präfix). PayPal wird
+beim Einrichten des Webhooks jedoch mit `https://<domain>/api/v1/payments/paypal/webhook`
+konfiguriert — dieser Pfad existierte nie und lieferte 404. Damit kamen
+PayPal-Zahlungsbestätigungen (`PAYMENT.CAPTURE.COMPLETED`,
+`PAYMENT.CAPTURE.DENIED`/`DECLINED`, `PAYMENT.CAPTURE.REFUNDED`) vermutlich
+seit Einführung der Route nie in der Anwendung an. Zahlungen, die über PayPal
+abgewickelt wurden, blieben serverseitig dauerhaft im Status `pending`, auch
+wenn PayPal die Zahlung erfolgreich abgeschlossen hatte.
+
+## Fix
+
+Die Route folgt jetzt dem Stil der übrigen Datei und nutzt die implizite
+`/api`-Präfixierung aus `bootstrap/app.php` sowie einen eigenen
+`Route::prefix('v1')`-Block:
+
+```php
+// PayPal webhook - separate without rate limiting (PayPal needs reliable access)
+Route::prefix('v1')->group(function () {
+    Route::post('/payments/paypal/webhook', [PaymentController::class, 'handleWebhook']);
+});
+```
+
+Effektiver Pfad jetzt: `/api/v1/payments/paypal/webhook` — exakt der Pfad,
+den PayPal beim Einrichten des Webhooks erwartet.
+
+Bewusst **beibehalten**:
+
+- Kein `auth:sanctum` auf dieser Route — PayPal kann sich nicht per
+  Sanctum-Session authentifizieren. Die Authentizität wird stattdessen im
+  Controller über `PayPalWebhookValidator::validate()` per Signaturprüfung
+  (`PAYPAL-TRANSMISSION-SIG` etc.) sichergestellt.
+- Keine eigene Rate-Limit-Middleware auf dieser Route, damit PayPal-Retries
+  zuverlässig ankommen (Kommentar im Code).
+
+## Verifikation
+
+```bash
+php artisan route:list --path=paypal
+# POST api/v1/payments/paypal/webhook  Api\PaymentController@handleWebhook
+```
+
+Regressionstest ergänzt in
+`backend/tests/Feature/PaymentApiTest.php`
+(`'paypal webhook is reachable at the external path PayPal is configured with, without authentication'`),
+der explizit den finalen, nach außen sichtbaren Pfad
+`/api/v1/payments/paypal/webhook` unauthentifiziert aufruft und eine
+`200 OK`-Antwort mit `status: success` erwartet.
+
+`composer qa` (Pint, PHPStan/Larastan, PHPCompatibility gegen PHP 8.2, Pest)
+lief danach vollständig grün (834 Tests, 2605 Assertions).
+
+## Empfehlung für den Betrieb
+
+Nach dem Deploy dieses Fixes sollte die Webhook-URL im PayPal Developer
+Dashboard (Sandbox und Live) überprüft bzw. neu verifiziert werden, da
+PayPal bei dauerhaft fehlschlagenden Zustellungen Webhooks deaktivieren kann.


### PR DESCRIPTION
## Summary

Produktionskritischer, vorbestehender Bug — gefunden während der Umsetzung von Change 3 (`add-invoice-payment-entry`), unabhängig davon.

`routes/api.php` registrierte den PayPal-Webhook mit dem hartkodierten Pfad `/api/v1/payments/paypal/webhook`. Da Laravel `routes/api.php` (laut `bootstrap/app.php`) bereits automatisch mit `/api` voranstellt — wie an allen anderen `Route::prefix('v1')`-Blöcken in derselben Datei erkennbar — war die effektive Route `/api/api/v1/payments/paypal/webhook`. Das ist nicht der Pfad, unter dem PayPal einen Webhook typischerweise konfiguriert bekommt (`https://domain.tld/api/v1/payments/paypal/webhook`) — der Webhook dürfte seit Einführung nie erreicht worden sein, d.h. Zahlungsbestätigungen von PayPal kamen vermutlich nie in der Anwendung an.

**Fix:** Route in einen `Route::prefix('v1')->group(...)`-Block verpackt (Stil der übrigen Datei), effektiver Pfad jetzt korrekt `/api/v1/payments/paypal/webhook` (per `php artisan route:list` verifiziert). Kein `auth:sanctum`, kein Rate-Limiting bewusst beibehalten (Signaturprüfung läuft über `PayPalWebhookValidator` im Controller).

## Test plan

- [x] `composer qa` grün (834 Tests, 2605 Assertions)
- [x] Neuer Regressionstest ruft explizit die tatsächliche äußere URL `/api/v1/payments/paypal/webhook` auf (kein bestehender Test hatte das vorher getan) und erwartet eine erfolgreiche Antwort statt 404
- [ ] Falls PayPal in Produktion/Demo bereits konfiguriert ist: Webhook-URL in den PayPal-Entwicklereinstellungen prüfen/neu bestätigen, da sich der technisch korrekte Pfad durch diesen Fix nicht geändert hat (er war vorher nur nicht erreichbar) — kein Handlungsbedarf auf PayPal-Seite erwartet, aber zur Sicherheit empfohlen

🤖 Generated with [Claude Code](https://claude.com/claude-code)