### PR TITLE
fix: PayPal-Webhook-Test auf korrigierten Pfad umstellen

### DIFF
--- a/backend/tests/Feature/Api/InvoicePaymentApiTest.php
+++ b/backend/tests/Feature/Api/InvoicePaymentApiTest.php
@@ -215,11 +215,7 @@ it('setzt den rechnungsstatus über den service auf paid wenn ein paypal-webhook
         'transaction_id' => 'CAPTURE-XYZ',
     ]);
 
-    // Note: this route is registered with a duplicated `/api` prefix
-    // (`routes/api.php` already runs under the framework's `api/` prefix,
-    // and the route definition itself additionally hardcodes `/api/v1/...`)
-    // — a pre-existing quirk, not something to fix as part of this task.
-    $this->postJson('/api/api/v1/payments/paypal/webhook', [
+    $this->postJson('/api/v1/payments/paypal/webhook', [
         'event_type' => 'PAYMENT.CAPTURE.COMPLETED',
         'resource' => ['id' => 'CAPTURE-XYZ'],
     ])->assertOk();


### PR DESCRIPTION
## Summary

`main` ist aktuell rot: Nach dem Merge von #90 (Change 3, Zahlungseingang) und #91 (PayPal-Webhook-Routing-Fix) kombiniert schlägt `InvoicePaymentApiTest.php::'it setzt den rechnungsstatus über den service auf paid wenn ein paypal-webhook eine zahlung abschließt'` fehl.

Ursache: Der Test wurde in #90 geschrieben, als die Webhook-Route noch doppelt-präfixiert war (`/api/api/v1/payments/paypal/webhook`), und rief bewusst genau diesen (damals korrekten, weil tatsächlich registrierten) Pfad auf — mit einem Kommentar, der das als "vorbestehende Eigenheit, nicht Teil dieser Task" auswies. #91 hat die Route korrigiert; der Test zielt seitdem auf einen nicht mehr existierenden Pfad und bekommt 404 statt 200.

Beide PRs liefen unabhängig voneinander durch eine grüne CI (die jeweils andere Änderung war zum Zeitpunkt des CI-Laufs noch nicht auf `main`), das Zusammenspiel wurde erst nach beiden Merges sichtbar.

**Fix:** Test auf den jetzt korrekten Pfad `/api/v1/payments/paypal/webhook` umgestellt, den nun nicht mehr zutreffenden Kommentar entfernt.

## Test plan

- [x] `vendor/bin/pest --filter=InvoicePaymentApiTest` grün (11/11)
- [x] Volle Suite `vendor/bin/pest --no-coverage` grün (856 passed, 2 erwartete SQLite-Concurrency-Skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)