### PR TITLE
fix: Geburtsdatum bei Hundeanlage optional

### DIFF
--- a/backend/app/Http/Requests/StoreDogRequest.php
+++ b/backend/app/Http/Requests/StoreDogRequest.php
@@ -35,7 +35,7 @@ class StoreDogRequest extends FormRequest
             'customerId' => ['required', 'integer', 'exists:customers,id'],
             'name' => ['required', 'string', 'max:255'],
             'breed' => ['required', 'string', 'max:255'],
-            'dateOfBirth' => ['required', 'date', 'before:today'],
+            'dateOfBirth' => ['nullable', 'date', 'before:today'],
             'gender' => ['required', 'in:male,female'],
             'chipNumber' => ['nullable', 'string', 'max:50', 'unique:dogs,chip_number'],
             'weight' => ['nullable', 'numeric', 'min:0', 'max:200'],

--- a/backend/tests/Feature/Api/DogApiTest.php
+++ b/backend/tests/Feature/Api/DogApiTest.php
@@ -333,7 +333,31 @@ describe('Dog API - Store', function () {
             ->postJson('/api/v1/dogs', []);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['customerId', 'name', 'breed', 'dateOfBirth', 'gender']);
+            ->assertJsonValidationErrors(['customerId', 'name', 'breed', 'gender']);
+    });
+
+    it('erstellt einen hund ohne geburtsdatum erfolgreich', function () {
+        $admin = User::factory()->admin()->create();
+        $customer = Customer::factory()->create();
+
+        $data = [
+            'customerId' => $customer->id,
+            'name' => 'Peanut',
+            'breed' => 'Chihuahua',
+            'gender' => 'female',
+        ];
+
+        $response = $this->actingAs($admin)
+            ->postJson('/api/v1/dogs', $data);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Peanut')
+            ->assertJsonPath('data.dateOfBirth', null);
+
+        $this->assertDatabaseHas('dogs', [
+            'name' => 'Peanut',
+            'date_of_birth' => null,
+        ]);
     });
 
     test('validates chip number uniqueness', function () {

--- a/openspec/triage/20260817-1044-dog-birthdate-optional.md
+++ b/openspec/triage/20260817-1044-dog-birthdate-optional.md
@@ -1,0 +1,59 @@
+# Triage: Geburtsdatum bei Hundeanlage optional machen
+
+**Pfad:** trivial
+**Geschätzter Umfang:** 1 Datei (Backend, PHP). Kein Frontend-Change nötig (siehe unten).
+**Risiko:** niedrig — reine Lockerung einer Validierungsregel (`required` → `nullable`), keine Migration, kein Schnittstellenbruch, kein Datenverlust.
+**Klarheit:** klar — eindeutige, einzeilige Anforderung.
+
+## Anforderung (Zusammenfassung)
+Beim Anlegen eines neuen Hundes soll das Geburtsdatum (`dateOfBirth`) kein
+Pflichtfeld mehr sein. Aktuell verlangt die Backend-Validierung beim direkten
+Anlegen eines Hundes (Admin/Trainer-Flow) ein Geburtsdatum; das soll entfallen,
+sodass Hunde auch ohne bekanntes Geburtsdatum angelegt werden können.
+
+## Codebasis-Befund (geprüft, nicht geraten)
+
+- **Migration** `backend/database/migrations/2025_12_22_184754_create_dogs_table.php:19`:
+  Spalte `date_of_birth` ist bereits `->nullable()`. **Keine Migration nötig.**
+- **Model** `backend/app/Models/Dog.php`:
+  - `getAgeAttribute()` (Zeile 138–145) ist bereits null-sicher (`if (! $this->date_of_birth) return null;`).
+  - `scopePuppies()` (Zeile 158–162) filtert bereits explizit mit `whereNotNull('date_of_birth')`.
+  - **Keine Model-Änderung nötig.**
+- **Validierung — der eigentliche Fund:**
+  - `backend/app/Http/Requests/StoreDogRequest.php:38` — Admin/Trainer-Flow zum direkten
+    Anlegen eines Hundes: `'dateOfBirth' => ['required', 'date', 'before:today']`.
+    **Das ist die Regel, die geändert werden muss** (→ `['nullable', 'date', 'before:today']`).
+  - `backend/app/Http/Requests/UpdateDogRequest.php:54` — beim Update bereits `sometimes` (kein Zwang).
+  - `backend/app/Http/Requests/StoreDogRegistrationRequest.php:40` — Kunden-Self-Service-Flow zur
+    Hunde-Registrierung hat `dateOfBirth` bereits als `nullable`. Dort ist nichts zu tun.
+- **Resource** `backend/app/Http/Resources/DogResource.php:33`: `$this->date_of_birth?->toDateString()`
+  ist bereits null-sicher. **Keine Änderung nötig.**
+- **Frontend** `frontend/src/components/DogFormModal.vue`:
+  - Das Geburtsdatum-Feld (Zeile 109–115, Label "Geburtsdatum") hat **kein** `*`-Pflichtfeld-Kennzeichen
+    und **kein** HTML-`required`-Attribut — im Gegensatz zu Besitzer, Name und Rasse (Zeilen 82/87, 97/98,
+    102/103, jeweils mit `*` im Label und `required`-Attribut).
+  - Das Frontend behandelt das Geburtsdatum **bereits als optional**. Es existiert sogar schon eine
+    deutsche Fehlermeldungs-Übersetzung für den Fall, dass das Backend "required" zurückmeldet
+    (Zeile 408: `'The date of birth field is required': 'Das Geburtsdatum ist erforderlich'`), die nach
+    der Änderung schlicht nicht mehr getriggert wird — kann bestehen bleiben oder optional entfernt werden.
+  - **Keine zwingende Frontend-Änderung nötig**, um die Anforderung zu erfüllen. Optional: die nun
+    tote Übersetzungszeile 408 aufräumen (kosmetisch, kein Muss).
+
+## Rückfragen an den User
+Keine — Anforderung ist eindeutig, Codebasis-Recherche bestätigt einen einzigen, klar lokalisierten
+Änderungspunkt.
+
+## Empfohlene nächste Aktion
+Kein Architekt nötig (trivial-Pfad). Direkt `dev-php` beauftragen:
+
+> Ändere `backend/app/Http/Requests/StoreDogRequest.php:38` von
+> `'dateOfBirth' => ['required', 'date', 'before:today']` zu
+> `'dateOfBirth' => ['nullable', 'date', 'before:today']`.
+> Passe ggf. zugehörige Feature-Tests unter `backend/tests/Feature/` an, die aktuell erwarten, dass
+> das Anlegen eines Hundes ohne `dateOfBirth` einen Validierungsfehler wirft, und ergänze einen Test,
+> der bestätigt, dass ein Hund ohne Geburtsdatum erfolgreich angelegt werden kann.
+
+Ablauf gemäß Trivial-Pfad in `~/.claude/WORKFLOW.md` (Edge Case "trivial"):
+Feature-Branch `feature/dog-birthdate-optional` anlegen → `dev-php` implementiert →
+`composer qa` laufen lassen → Commit `fix: Geburtsdatum bei Hundeanlage optional machen` → PR.
+Kein openspec-Change, kein Architekt/Skeptiker nötig.

--- a/openspec/triage/20260817-1044-dog-birthdate-optional.notes.md
+++ b/openspec/triage/20260817-1044-dog-birthdate-optional.notes.md
@@ -1,0 +1,59 @@
+# Notizen: Geburtsdatum bei Hundeanlage optional machen (Trivial-Fix)
+
+**Bezug:** `openspec/triage/20260817-1044-dog-birthdate-optional.md`
+**Ausführender Agent:** dev-php
+**Datum:** 2026-08-17
+
+## Änderungen
+
+1. `backend/app/Http/Requests/StoreDogRequest.php:38`
+   Regel für `dateOfBirth` von `['required', 'date', 'before:today']` auf
+   `['nullable', 'date', 'before:today']` geändert — analog zu
+   `StoreDogRegistrationRequest.php:40`.
+
+2. `backend/tests/Feature/Api/DogApiTest.php`
+   - Test `'validates required fields'` (Zeile ~329) korrigiert: `dateOfBirth`
+     aus der Liste der erwarteten Pflichtfeld-Validierungsfehler entfernt
+     (widersprach sonst dem neuen Sollverhalten).
+   - Neuer Test ergänzt: `it('erstellt einen hund ohne geburtsdatum erfolgreich', …)`
+     — legt einen Hund ohne `dateOfBirth` an, erwartet HTTP 201, `data.dateOfBirth === null`
+     und `date_of_birth === null` in der DB.
+
+## Verifikation der laut Triage bereits korrekten Stellen (nur gelesen, nicht geändert)
+
+- Migration `2025_12_22_184754_create_dogs_table.php`: Spalte `date_of_birth`
+  bereits `->nullable()`. Bestätigt, keine Änderung nötig.
+- `App\Models\Dog::getAgeAttribute()` / `scopePuppies()`: bereits null-sicher.
+  Bestätigt, keine Änderung nötig.
+- `UpdateDogRequest.php`: nutzt bereits `sometimes`. Bestätigt, keine Änderung nötig.
+- `DogResource.php`: `$this->date_of_birth?->toDateString()` bereits null-safe.
+  Bestätigt, keine Änderung nötig.
+- Frontend `DogFormModal.vue`: Geburtsdatum-Feld hat bereits kein `required`.
+  Nicht angefasst (außerhalb PHP-Zuständigkeit dieser Task).
+
+## Keine weiteren betroffenen Tests
+
+`grep -rn "dateOfBirth" backend/tests/` zeigt keine weiteren Stellen, die
+`dateOfBirth` als Pflichtfeld beim Anlegen voraussetzen
+(`DogRegistrationRequestApiTest.php` betrifft den bereits korrekten
+Customer-Self-Service-Flow und war nicht betroffen).
+
+## QA-Ergebnis
+
+`docker compose exec php composer qa` (PHP-CS-Fixer, PHPStan/Larastan,
+PHPCompatibility gegen PHP 8.2, Pest) — alles grün:
+
+- Lint (PHP-CS-Fixer): PASS, 334 Dateien
+- PHPStan/Larastan: `[OK] No errors`
+- PHPCompatibility (testVersion 8.2): keine Verstöße
+- Pest: 893 passed, 3 skipped (bekannte, unabhängige Concurrency-Tests, die
+  eine echte MVCC-DB statt SQLite brauchen — siehe deren eigene Notizen,
+  nicht Teil dieser Task)
+
+Kein Bezug zu MySQL/Postgres-Portabilität, da reine Validierungsregel-Änderung
+ohne SQL/Migration-Bezug.
+
+## Task abgehakt
+
+Kein `tasks.md` vorhanden (Trivial-Pfad, kein voller openspec-Change gemäß
+Empfehlung der Triage-Datei). Diese Notizdatei dokumentiert den Abschluss.


### PR DESCRIPTION
## Summary
- `dateOfBirth` in `StoreDogRequest` war fälschlich `required`, obwohl Migration, Model, `UpdateDogRequest`, `StoreDogRegistrationRequest`, `DogResource` und das Frontend-Formular das Feld bereits als optional behandeln — Regel auf `nullable` geändert.
- Bestehenden Feature-Test korrigiert, der die alte Pflichtfeld-Annahme voraussetzte; neuen Test ergänzt, der das erfolgreiche Anlegen eines Hundes ohne Geburtsdatum abdeckt.

## Test plan
- [x] `composer qa` (Lint, PHPStan/Larastan, PHPCompatibility gegen PHP 8.2, Pest) — alles grün
- [x] Neuer Pest-Test: Hund ohne `dateOfBirth` anlegen → HTTP 201, `dateOfBirth` ist `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)